### PR TITLE
Add low VRAM feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Launch server for live interaction (temporary SSL certs for https):
 SSL_DIR=$(mktemp -d); python -m moshi.server --ssl "$SSL_DIR"
 ```
 
+**CPU Offload:** If your GPU has insufficient memory, use the `--cpu-offload` flag to offload model layers to CPU. This requires the `accelerate` package (`pip install accelerate`):
+```bash
+SSL_DIR=$(mktemp -d); python -m moshi.server --ssl "$SSL_DIR" --cpu-offload
+```
+
 Access the Web UI from a browser at `localhost:8998` if running locally, otherwise look for the access link printed by the script:
 ```
 Access the Web UI directly at https://11.54.401.33:8998
@@ -44,6 +49,8 @@ Access the Web UI directly at https://11.54.401.33:8998
 ### Offline Evaluation
 
 For offline evaluation use the offline script that streams in an input wav file and produces an output wav file from the captured output stream. The output file will be the same duration as the input file.
+
+Add `--cpu-offload` to any command below if your GPU has insufficient memory (requires `accelerate` package).
 
 **Assistant example:**
 ```bash

--- a/moshi/moshi/offline.py
+++ b/moshi/moshi/offline.py
@@ -168,6 +168,7 @@ def run_inference(
     topk_text: int,
     greedy: bool,
     save_voice_prompt_embeddings: bool,
+    cpu_offload: bool = False,
 ):
     """Run offline inference using an input WAV as the user-side stream.
 
@@ -202,7 +203,7 @@ def run_inference(
     log("info", "loading moshi")
     if moshi_weight is None:
         moshi_weight = hf_hub_download(hf_repo, loaders.MOSHI_NAME)  # type: ignore
-    lm = loaders.get_moshi_lm(moshi_weight, device=device)
+    lm = loaders.get_moshi_lm(moshi_weight, device=device, cpu_offload=cpu_offload)
     lm.eval()
     log("info", "moshi loaded")
 
@@ -376,6 +377,9 @@ def main():
     parser.add_argument(
         "--device", type=str, default="cuda", help="Device on which to run, defaults to 'cuda'."
     )
+    parser.add_argument("--cpu-offload", action="store_true",
+                        help="Offload LM model layers to CPU when GPU memory is insufficient. "
+                             "Requires 'accelerate' package.")
     parser.add_argument("--seed", type=int, default=-1, help="Seed for reproducibility (-1 disables)")
 
     args = parser.parse_args()
@@ -419,6 +423,7 @@ def main():
             topk_text=args.topk_text,
             greedy=greedy,
             save_voice_prompt_embeddings=False,
+            cpu_offload=args.cpu_offload,
         )
 
 

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -370,6 +370,9 @@ def main():
                         help="HF repo to look into, defaults PersonaPlex. "
                              "Use this to select a different pre-trained model.")
     parser.add_argument("--device", type=str, default="cuda", help="Device on which to run, defaults to 'cuda'.")
+    parser.add_argument("--cpu-offload", action="store_true",
+                        help="Offload LM model layers to CPU when GPU memory is insufficient. "
+                             "Requires 'accelerate' package.")
     parser.add_argument(
         "--voice-prompt-dir",
         type=str,
@@ -439,7 +442,7 @@ def main():
     logger.info("loading moshi")
     if args.moshi_weight is None:
         args.moshi_weight = hf_hub_download(args.hf_repo, loaders.MOSHI_NAME)
-    lm = loaders.get_moshi_lm(args.moshi_weight, device=args.device)
+    lm = loaders.get_moshi_lm(args.moshi_weight, device=args.device, cpu_offload=args.cpu_offload)
     lm.eval()
     logger.info("moshi loaded")
     state = ServerState(


### PR DESCRIPTION
## Summary
- Add `--cpu-offload` flag to server and offline scripts for running Moshi on GPUs with limited VRAM
- Implement automatic model layer distribution across GPU and CPU using the `accelerate` library

**Details:**

This PR enables users with GPUs that have insufficient memory to run Moshi by offloading model layers to CPU. When `--cpu-offload` is specified:

1. The model is first loaded entirely on CPU
2. `accelerate.infer_auto_device_map()` determines optimal layer placement based on available GPU memory
3. `accelerate.dispatch_model()` distributes the model across GPU and CPU
4. Layers on CPU are automatically moved to GPU during forward pass as needed

The implementation preserves the existing weight patching logic for depformer layers and maintains backward compatibility - the flag is optional and the default behavior is unchanged.