### PR TITLE
Simplify install: add PyTorch cu130 repo for torch/vision/audio

### DIFF
--- a/moshi/pyproject.toml
+++ b/moshi/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "torchvision == 0.25.0",
     "torchaudio == 2.10.0",
     "aiohttp>=3.10.5, <3.11",
+    "accelerate==1.12.0",
 ]
 authors = [{name="Rajarshi Roy", email="rajarshir@nvidia.com"}]
 maintainers = [{name="Rajarshi Roy", email="rajarshir@nvidia.com"}]

--- a/moshi/pyproject.toml
+++ b/moshi/pyproject.toml
@@ -10,11 +10,11 @@ dependencies = [
     "sentencepiece == 0.2",
     "sounddevice == 0.5",
     "sphn >= 0.1.4, < 0.2",
-    "torch == 2.10.0",
-    "torchvision == 0.25.0",
-    "torchaudio == 2.10.0",
-    "aiohttp>=3.10.5, <3.11",
-    "accelerate==1.12.0",
+    "torch >= 2.9, < 2.11",
+    "torchaudio >= 2.9, < 2.11",
+    "torchvision >= 0.24, < 0.26",
+    "aiohttp >= 3.10.5, < 3.11",
+    "accelerate >= 1.12, < 1.13",
 ]
 authors = [{name="Rajarshi Roy", email="rajarshir@nvidia.com"}]
 maintainers = [{name="Rajarshi Roy", email="rajarshir@nvidia.com"}]
@@ -34,9 +34,9 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv.sources]
-torch = [{ index = "pytorch-cu130" }]
-torchvision = [{ index = "pytorch-cu130" }]
-torchaudio = [{ index = "pytorch-cu130" }]
+torch = [{ index = "pytorch-cu130", marker = "sys_platform != 'darwin'" }]
+torchvision = [{ index = "pytorch-cu130", marker = "sys_platform != 'darwin'" }]
+torchaudio = [{ index = "pytorch-cu130", marker = "sys_platform != 'darwin'" }]
 
 [[tool.uv.index]]
 name = "pytorch-cu130"

--- a/moshi/pyproject.toml
+++ b/moshi/pyproject.toml
@@ -10,7 +10,9 @@ dependencies = [
     "sentencepiece == 0.2",
     "sounddevice == 0.5",
     "sphn >= 0.1.4, < 0.2",
-    "torch >= 2.2.0, < 2.5",
+    "torch == 2.10.0",
+    "torchvision == 0.25.0",
+    "torchaudio == 2.10.0",
     "aiohttp>=3.10.5, <3.11",
 ]
 authors = [{name="Rajarshi Roy", email="rajarshir@nvidia.com"}]
@@ -29,3 +31,13 @@ version = {attr = "moshi.__version__"}
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.uv.sources]
+torch = [{ index = "pytorch-cu130" }]
+torchvision = [{ index = "pytorch-cu130" }]
+torchaudio = [{ index = "pytorch-cu130" }]
+
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
+explicit = true

--- a/moshi/requirements.txt
+++ b/moshi/requirements.txt
@@ -10,3 +10,4 @@ sentencepiece==0.2
 sounddevice==0.5
 sphn>=0.1.4,<0.2
 aiohttp>=3.10.5,<3.11
+accelerate==1.12.0

--- a/moshi/requirements.txt
+++ b/moshi/requirements.txt
@@ -1,7 +1,10 @@
 --extra-index-url https://download.pytorch.org/whl/cu130
-torch==2.10.0+cu130
-torchvision==0.25.0+cu130
-torchaudio==2.10.0+cu130
+torch==2.10.0+cu130; sys_platform != "darwin"
+torchaudio==2.10.0+cu130; sys_platform != "darwin"
+torchvision==0.25.0+cu130; sys_platform != "darwin"
+torch>=2.9,<2.11; sys_platform == "darwin"
+torchaudio>=2.9,<2.11; sys_platform == "darwin"
+torchvision>=0.25,<0.26; sys_platform == "darwin"
 numpy>=1.26,<2.2
 safetensors>=0.4.0,<0.5
 huggingface-hub>=0.24,<0.25
@@ -10,4 +13,4 @@ sentencepiece==0.2
 sounddevice==0.5
 sphn>=0.1.4,<0.2
 aiohttp>=3.10.5,<3.11
-accelerate==1.12.0
+accelerate>=1.12,<1.13

--- a/moshi/requirements.txt
+++ b/moshi/requirements.txt
@@ -1,3 +1,7 @@
+--extra-index-url https://download.pytorch.org/whl/cu130
+torch==2.10.0+cu130
+torchvision==0.25.0+cu130
+torchaudio==2.10.0+cu130
 numpy>=1.26,<2.2
 safetensors>=0.4.0,<0.5
 huggingface-hub>=0.24,<0.25
@@ -5,5 +9,4 @@ einops==0.7
 sentencepiece==0.2
 sounddevice==0.5
 sphn>=0.1.4,<0.2
-torch>=2.2.0,<2.5
 aiohttp>=3.10.5,<3.11


### PR DESCRIPTION
Changes:

- Added PyTorch wheel repository https://download.pytorch.org/whl/cu130 to make installing torch, torchvision, and torchaudio easier and to simplify Docker image builds. 

- The installation for macOS is left with pypi.org.

- Added package `accelerate`, which is required when running with the `--cpu-offload` flag.

```
ImportError: CPU offloading requires the 'accelerate' package. Install it with: pip install accelerate
```

Possible installation options:
```
docker compose build
```
```
pip install -r moshi/requirements.txt
```
```
uv pip install moshi/.
```
```
pip install moshi/.
pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130
```

These changes simplify and automate the deployment process.

Fix #23 #31
