### PR TITLE
docs: add troubleshooting section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ python -m moshi.offline \
   --output-text "output.json"
 ```
 
+### Troubleshooting
+
+**Torch not compiled with CUDA enabled**
+
+If you encounter an error like `AssertionError: Torch not compiled with CUDA enabled`, it means your PyTorch installation does not support CUDA or you are running on a machine without NVIDIA GPUs (e.g., macOS). You must explicitly specify the CPU device:
+```bash
+python -m moshi.server --ssl "$SSL_DIR" --device cpu
+```
+
+**401 Unauthorized / Gated Repo Error**
+
+If you see a 401 Unauthorized error when downloading models, ensure you have:
+1. Created a Hugging Face account.
+2. Accepted the model license on the [PersonaPlex model page](https://huggingface.co/nvidia/personaplex-7b-v1).
+3. Logged in locally using the CLI:
+```bash
+huggingface-cli login
+```
+
 ## Voices
 
 PersonaPlex supports a wide range of voices; we pre-package embeddings for voices that sound more natural and conversational (NAT) and others that are more varied (VAR). The fixed set of voices are labeled:


### PR DESCRIPTION
## Summary
Added a troubleshooting section to the README to address common issues encountered by users:
- **Torch not compiled with CUDA enabled**: Added instructions to use `--device cpu` for systems without CUDA support (e.g., macOS).
- **401 Unauthorized / Gated Repo Error**: Added instructions on how to authenticate with Hugging Face to access the gated model.

These additions should help users troubleshoot startup issues more effectively.