### PR TITLE
Fix device placement when loading voice prompt embeddings

### DIFF
--- a/moshi/moshi/models/lm.py
+++ b/moshi/moshi/models/lm.py
@@ -976,7 +976,7 @@ class LMGen(StreamingModule[_LMGenState]):
 
     def load_voice_prompt_embeddings(self, path: str):
         self.voice_prompt = path
-        state = torch.load(path)
+        state = torch.load(path, map_location=self.lm_model.device)
 
         self.voice_prompt_audio = None
         self.voice_prompt_embeddings = state["embeddings"].to(self.lm_model.device)


### PR DESCRIPTION
Add map_location to torch.load() to ensure embeddings load directly onto the model's device instead of defaulting to CPU.