### PR TITLE
fix: update .dockerignore to exclude build artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
-.cache
+.cache/
+moshi/build/
+moshi/*egg-info/


### PR DESCRIPTION
Removed unnecessary artifacts from the Docker build context: `moshi/build/` and `moshi/*egg-info/`. These directories are created by local builds or installs and are not needed in the container, but they were being copied into the image via `COPY` and frequently invalidated the Docker cache. They are now ignored, so rebuilds are more stable and the steps after `COPY` run less often.