### PR TITLE
fix: skip config.json download counter when HF_HUB_OFFLINE is set

### DIFF
--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -426,7 +426,9 @@ def main():
 
     # Download config.json to increment download counter
     # No worries about double-counting since config.json will be cached the second time
-    hf_hub_download(args.hf_repo, "config.json")
+    # Skip when running in offline mode (HF_HUB_OFFLINE=1)
+    if not os.environ.get("HF_HUB_OFFLINE"):
+        hf_hub_download(args.hf_repo, "config.json")
 
     logger.info("loading mimi")
     if args.mimi_weight is None:


### PR DESCRIPTION
## Problem

Line 429 in `server.py` calls `hf_hub_download(args.hf_repo, "config.json")` unconditionally to increment the download counter. When `HF_HUB_OFFLINE=1` is set, this fails because the HuggingFace Hub client cannot reach the server.

## Fix

Guard the download counter call with `os.environ.get("HF_HUB_OFFLINE")`. The call is only used for analytics and is not required for the server to function.

Fixes #54