### PR TITLE
fix: use safe deserialization and tarfile extraction

### DIFF
--- a/moshi/moshi/models/lm.py
+++ b/moshi/moshi/models/lm.py
@@ -976,7 +976,7 @@ class LMGen(StreamingModule[_LMGenState]):
 
     def load_voice_prompt_embeddings(self, path: str):
         self.voice_prompt = path
-        state = torch.load(path)
+        state = torch.load(path, weights_only=True)
 
         self.voice_prompt_audio = None
         self.voice_prompt_embeddings = state["embeddings"].to(self.lm_model.device)

--- a/moshi/moshi/models/loaders.py
+++ b/moshi/moshi/models/loaders.py
@@ -157,7 +157,7 @@ def get_mimi(filename: str | Path,
     if _is_safetensors(filename):
         load_model(model, filename)
     else:
-        pkg = torch.load(filename, "cpu")
+        pkg = torch.load(filename, "cpu", weights_only=True)
         model.load_state_dict(pkg["model"])
     model.set_num_codebooks(8)
     return model
@@ -214,7 +214,7 @@ def get_moshi_lm(
     else:
         # torch checkpoint
         with open(filename, "rb") as f:
-            state_dict = torch.load(f, map_location="cpu")
+            state_dict = torch.load(f, map_location="cpu", weights_only=True)
     # Patch 1: expand depformer self_attn weights if needed
     model_sd = model.state_dict()
     for name, tensor in list(state_dict.items()):
@@ -292,7 +292,7 @@ def _get_moshi_lm_with_offload(
         state_dict = load_file(filename, device="cpu")
     else:
         with open(filename, "rb") as f:
-            state_dict = torch.load(f, map_location="cpu")
+            state_dict = torch.load(f, map_location="cpu", weights_only=True)
 
     # Apply weight patches (same as non-offload path)
     model_sd = model.state_dict()

--- a/moshi/moshi/offline.py
+++ b/moshi/moshi/offline.py
@@ -142,7 +142,7 @@ def _get_voice_prompt_dir(voice_prompt_dir: Optional[str], hf_repo: str) -> Opti
     if not voices_dir.exists():
         log("info", f"extracting {voices_tgz} to {voices_dir}")
         with tarfile.open(voices_tgz, "r:gz") as tar:
-            tar.extractall(path=voices_tgz.parent)
+            tar.extractall(path=voices_tgz.parent, filter='data')
 
     if not voices_dir.exists():
         raise RuntimeError("voices.tgz did not contain a 'voices/' directory")

--- a/moshi/moshi/offline.py
+++ b/moshi/moshi/offline.py
@@ -41,6 +41,7 @@ keep parity with voice-prompt feeding logic in the server.
 
 import argparse
 import os
+import sys
 import tarfile
 from pathlib import Path
 import json
@@ -142,7 +143,14 @@ def _get_voice_prompt_dir(voice_prompt_dir: Optional[str], hf_repo: str) -> Opti
     if not voices_dir.exists():
         log("info", f"extracting {voices_tgz} to {voices_dir}")
         with tarfile.open(voices_tgz, "r:gz") as tar:
-            tar.extractall(path=voices_tgz.parent, filter='data')
+            if sys.version_info >= (3, 12):
+                tar.extractall(path=voices_tgz.parent, filter='data')
+            else:
+                # Safe extraction fallback for Python < 3.12
+                for member in tar.getmembers():
+                    if member.name.startswith('/') or '..' in member.name:
+                        raise ValueError(f"Unsafe tar member: {member.name}")
+                    tar.extract(member, path=voices_tgz.parent)
 
     if not voices_dir.exists():
         raise RuntimeError("voices.tgz did not contain a 'voices/' directory")

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -330,7 +330,14 @@ def _get_voice_prompt_dir(voice_prompt_dir: Optional[str], hf_repo: str) -> Opti
     if not voices_dir.exists():
         logger.info(f"extracting {voices_tgz} to {voices_dir}")
         with tarfile.open(voices_tgz, "r:gz") as tar:
-            tar.extractall(path=voices_tgz.parent, filter='data')
+            if sys.version_info >= (3, 12):
+                tar.extractall(path=voices_tgz.parent, filter='data')
+            else:
+                # Safe extraction fallback for Python < 3.12
+                for member in tar.getmembers():
+                    if member.name.startswith('/') or '..' in member.name:
+                        raise ValueError(f"Unsafe tar member: {member.name}")
+                    tar.extract(member, path=voices_tgz.parent)
 
     if not voices_dir.exists():
         raise RuntimeError("voices.tgz did not contain a 'voices/' directory")
@@ -346,7 +353,14 @@ def _get_static_path(static: Optional[str]) -> Optional[str]:
         dist = dist_tgz.parent / "dist"
         if not dist.exists():
             with tarfile.open(dist_tgz, "r:gz") as tar:
-                tar.extractall(path=dist_tgz.parent, filter='data')
+                if sys.version_info >= (3, 12):
+                    tar.extractall(path=dist_tgz.parent, filter='data')
+                else:
+                    # Safe extraction fallback for Python < 3.12
+                    for member in tar.getmembers():
+                        if member.name.startswith('/') or '..' in member.name:
+                            raise ValueError(f"Unsafe tar member: {member.name}")
+                        tar.extract(member, path=dist_tgz.parent)
         return str(dist)
     elif static != "none":
         # When set to the "none" string, we don't serve any static content.

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -330,7 +330,7 @@ def _get_voice_prompt_dir(voice_prompt_dir: Optional[str], hf_repo: str) -> Opti
     if not voices_dir.exists():
         logger.info(f"extracting {voices_tgz} to {voices_dir}")
         with tarfile.open(voices_tgz, "r:gz") as tar:
-            tar.extractall(path=voices_tgz.parent)
+            tar.extractall(path=voices_tgz.parent, filter='data')
 
     if not voices_dir.exists():
         raise RuntimeError("voices.tgz did not contain a 'voices/' directory")
@@ -346,7 +346,7 @@ def _get_static_path(static: Optional[str]) -> Optional[str]:
         dist = dist_tgz.parent / "dist"
         if not dist.exists():
             with tarfile.open(dist_tgz, "r:gz") as tar:
-                tar.extractall(path=dist_tgz.parent)
+                tar.extractall(path=dist_tgz.parent, filter='data')
         return str(dist)
     elif static != "none":
         # When set to the "none" string, we don't serve any static content.


### PR DESCRIPTION
## Summary

- Add `weights_only=True` to all `torch.load()` calls to prevent arbitrary code execution via pickle deserialization (CVE-2025-32434, CWE-502)
- Add `filter='data'` to all `tarfile.extractall()` calls to prevent path traversal attacks (CVE-2007-4559, CWE-22)

## Files Changed

| File | Fix |
|------|-----|
| `moshi/moshi/models/lm.py` line ~979 | `torch.load(..., weights_only=True)` |
| `moshi/moshi/models/loaders.py` lines ~160, ~217, ~295 | `torch.load(..., weights_only=True)` |
| `moshi/moshi/server.py` lines ~333, ~349 | `tarfile.extractall(..., filter='data')` |
| `moshi/moshi/offline.py` line ~145 | `tarfile.extractall(..., filter='data')` |

## Security Impact

**`torch.load()` without `weights_only=True`** deserializes arbitrary Python objects via pickle, allowing remote code execution if a malicious checkpoint file is loaded. The `weights_only=True` flag restricts deserialization to tensor data only.

**`tarfile.extractall()` without `filter='data'`** can be exploited via crafted archives containing `../` path components (tar slip / directory traversal). The `filter='data'` argument (available since Python 3.12, backported to 3.11.4+) strips dangerous metadata and blocks absolute/traversal paths.

## Test Plan

- [ ] Verify model loading still works with `weights_only=True` on standard `.pt` checkpoints
- [ ] Verify `tarfile` extraction of `voices.tgz` and `dist.tgz` succeeds with `filter='data'`
- [ ] Confirm no regressions in existing test suite