### PR TITLE
refactor: remove unused other_mimi MimiModel instance (~200MB memory savings)

### DIFF
--- a/moshi/moshi/offline.py
+++ b/moshi/moshi/offline.py
@@ -90,7 +90,7 @@ def wrap_with_system_tags(text: str) -> str:
     return f"<system> {cleaned} <system>"
 
 
-def warmup(mimi: MimiModel, other_mimi: MimiModel, lm_gen: LMGen, device: str, frame_size: int):
+def warmup(mimi: MimiModel, lm_gen: LMGen, device: str, frame_size: int):
     """Run a short warmup loop to initialize CUDA graphs and streaming state.
 
     Replicates the same warmup behavior as server.py: zeros → encode → LMGen.step → decode.
@@ -98,26 +98,23 @@ def warmup(mimi: MimiModel, other_mimi: MimiModel, lm_gen: LMGen, device: str, f
     for _ in range(4):
         chunk = torch.zeros(1, 1, frame_size, dtype=torch.float32, device=device)
         codes = mimi.encode(chunk)
-        _ = other_mimi.encode(chunk)
         for c in range(codes.shape[-1]):
             tokens = lm_gen.step(codes[:, :, c : c + 1])
             if tokens is None:
                 continue
             # Decode agent audio channels to ensure decode graphs/states are primed
             _ = mimi.decode(tokens[:, 1:9])
-            _ = other_mimi.decode(tokens[:, 1:9])
     if torch.cuda.is_available():
         torch.cuda.synchronize()
 
 
-def decode_tokens_to_pcm(mimi: MimiModel, other_mimi: MimiModel, lm_gen: LMGen, tokens: torch.Tensor) -> np.ndarray:
+def decode_tokens_to_pcm(mimi: MimiModel, lm_gen: LMGen, tokens: torch.Tensor) -> np.ndarray:
     """Decode a single step of model tokens to PCM using Mimi.
 
     tokens is shaped [B, dep_q+1, 1]; channels 1..dep_q are the agent audio codebooks.
     Returns a 1D float32 numpy array (mono) for the current frame.
     """
     pcm = mimi.decode(tokens[:, 1:9])
-    _ = other_mimi.decode(tokens[:, 1:9])
     pcm = pcm.detach().cpu().numpy()[0, 0]
     return pcm
 
@@ -191,7 +188,6 @@ def run_inference(
     if mimi_weight is None:
         mimi_weight = hf_hub_download(hf_repo, loaders.MIMI_NAME)  # type: ignore
     mimi = loaders.get_mimi(mimi_weight, device)
-    other_mimi = loaders.get_mimi(mimi_weight, device)
     log("info", "mimi loaded")
 
     # 2) Load tokenizer
@@ -224,12 +220,11 @@ def run_inference(
     )
     # Keep models in streaming mode similar to the server
     mimi.streaming_forever(1)
-    other_mimi.streaming_forever(1)
     lm_gen.streaming_forever(1)
 
     # 5) Warmup
     log("info", "warming up the model")
-    warmup(mimi, other_mimi, lm_gen, device, frame_size)
+    warmup(mimi, lm_gen, device, frame_size)
 
     # 6) Prompt configuration (text + voice)
     # System text tokens (k=0) and agent voice-prompt audio (k=1..dep_q) are forced
@@ -248,7 +243,6 @@ def run_inference(
     #    - Text prompt injection
     #    - Final audio silence
     mimi.reset_streaming()
-    other_mimi.reset_streaming()
     lm_gen.reset_streaming()
     lm_gen.step_system_prompts(mimi)
     # Reset mimi streaming after voice prompt encoding
@@ -280,7 +274,7 @@ def run_inference(
             if tokens is None:
                 continue
             # Decode current sampled agent frame to PCM
-            pcm = decode_tokens_to_pcm(mimi, other_mimi, lm_gen, tokens)
+            pcm = decode_tokens_to_pcm(mimi, lm_gen, tokens)
             generated_frames.append(pcm)
             # Decode text token
             text_token = tokens[0, 0, 0].item()


### PR DESCRIPTION
## Summary

Removes the second `MimiModel` instance (`other_mimi`) from `server.py` and `offline.py`. Every call to `other_mimi.encode()` and `other_mimi.decode()` discards the result by assigning to `_`. The primary `mimi` instance produces all actual output. Removing `other_mimi` frees ~200MB GPU memory.

## Why this matters

[#46](https://github.com/NVIDIA/personaplex/issues/46) identified that `other_mimi` loads a full copy of the Mimi codec weights but never uses any output. On memory-constrained deployments (consumer GPUs, Jetson), 200MB is significant.

## Changes

**`moshi/moshi/server.py`:**
- Removed `other_mimi` field from `ServerState` dataclass
- Removed `other_mimi` parameter from `__init__`, `warmup`, and `handle_chat`
- Removed `other_mimi = loaders.get_mimi(...)` instantiation in `main()`
- Removed all `_ = self.other_mimi.encode(chunk)` and `_ = self.other_mimi.decode(tokens[:, 1:9])` calls

**`moshi/moshi/offline.py`:**
- Removed `other_mimi` parameter from `warmup()` and `decode_tokens_to_pcm()`
- Removed `other_mimi = loaders.get_mimi(...)` instantiation in `run_inference()`
- Removed all `_ = other_mimi.encode(chunk)` and `_ = other_mimi.decode(tokens[:, 1:9])` calls

Net: -22 lines, +6 lines (signature adjustments).

## Testing

Verified via `grep -rn other_mimi --include="*.py"` that zero references remain. The primary `mimi` encode/decode path is untouched.

No test suite exists in this repo.

## Note for maintainer

If `other_mimi` was intended for a future streaming state feature or a separate voice prompt encoding path, please let me know and I'll revert. Based on the current code, all its outputs are discarded.

Fixes #46

This contribution was developed with AI assistance (Claude Code).