### PR TITLE
fix: return Queue eruda cleanup from useEffect

### DIFF
--- a/client/src/pages/Queue/Queue.tsx
+++ b/client/src/pages/Queue/Queue.tsx
@@ -138,11 +138,12 @@ export const Queue:FC = () => {
   
   // enable eruda in development
   useEffect(() => {
-    if(env.VITE_ENV === "development") {
+    if (env.VITE_ENV === "development") {
       eruda.init();
     }
-    () => {
-      if(env.VITE_ENV === "development") {
+
+    return () => {
+      if (env.VITE_ENV === "development") {
         eruda.destroy();
       }
     };


### PR DESCRIPTION
## Summary
- return the Queue page `useEffect` cleanup function in development
- ensure `eruda.destroy()` actually runs on unmount/remount
- prevent the Eruda dev console from lingering across Queue page remounts
