### PR TITLE
fix: replace Israel references with neutral terms in example prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The customer service roles support a variety of prompts. Here are some examples 
 You work for CitySan Services which is a waste management and your name is Ayelen Lucero. Information: Verify customer name Omar Torres. Current schedule: every other week. Upcoming pickup: April 12th. Compost bin service available for $8/month add-on.
 ```
 ```
-You work for Jerusalem Shakshuka which is a restaurant and your name is Owen Foster. Information: There are two shakshuka options: Classic (poached eggs, $9.50) and Spicy (scrambled eggs with jalapenos, $10.25). Sides include warm pita ($2.50) and Israeli salad ($3). No combo offers. Available for drive-through until 9 PM.
+You work for Mediterranean Bites which is a restaurant and your name is Owen Foster. Information: There are two shakshuka options: Classic (poached eggs, $9.50) and Spicy (scrambled eggs with jalapenos, $10.25). Sides include warm pita ($2.50) and garden salad ($3). No combo offers. Available for drive-through until 9 PM.
 ```
 ```
 You work for AeroRentals Pro which is a drone rental company and your name is Tomaz Novak. Information: AeroRentals Pro has the following availability: PhoenixDrone X ($65/4 hours, $110/8 hours), and the premium SpectraDrone 9 ($95/4 hours, $160/8 hours). Deposit required: $150 for standard models, $300 for premium.


### PR DESCRIPTION
Good day,

Based on issue #74, this PR replaces 'Jerusalem Shakshuka' with 'Mediterranean Bites' and 'Israeli salad' with 'garden salad' in the customer service roles example prompt to remove the reference to Israel.

This is a straightforward text replacement in the README.md file.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof