### PR TITLE
fix: detect MPS automatically and document macOS setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ sudo apt install libopus-dev
 
 # Fedora/RHEL
 sudo dnf install opus-devel
+
+# macOS (Homebrew)
+brew install opus
 ```
 
 ### Installation
@@ -45,6 +48,26 @@ Then set up your Huggingface authentication:
 ```bash
 export HF_TOKEN=<YOUR_HUGGINGFACE_TOKEN>
 ```
+
+### Device Selection
+
+`moshi.server` now auto-selects `cuda`, then `mps`, then `cpu`.
+
+On Apple Silicon, you can also force Metal explicitly:
+```bash
+SSL_DIR=$(mktemp -d); python -m moshi.server --ssl "$SSL_DIR" --device mps
+```
+
+`moshi.offline` accepts the same `--device` flag, for example:
+```bash
+python -m moshi.offline --device mps \
+  --voice-prompt "NATF2.pt" \
+  --input-wav "assets/test/input_assistant.wav" \
+  --output-wav "output.wav" \
+  --output-text "output.json"
+```
+
+Note: MPS support depends on the local PyTorch build and Apple Metal support available on the host machine.
 
 ### Launch Server
 

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -52,7 +52,7 @@ from .utils.logging import setup_logger, ColorizedLog
 
 
 logger = setup_logger(__name__)
-DeviceString = Literal["cuda"] | Literal["cpu"] #| Literal["mps"]
+DeviceString = Literal["cuda"] | Literal["cpu"] | Literal["mps"]
 
 def torch_auto_device(requested: Optional[DeviceString] = None) -> torch.device:
     """Return a torch.device based on the requested string or availability."""
@@ -60,8 +60,8 @@ def torch_auto_device(requested: Optional[DeviceString] = None) -> torch.device:
         return torch.device(requested)
     if torch.cuda.is_available():
         return torch.device("cuda")
-    #elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-    #    return torch.device("mps")
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return torch.device("mps")
     return torch.device("cpu")
 
 


### PR DESCRIPTION
## Summary
- re-enable automatic MPS device selection when CUDA is unavailable
- document macOS/Homebrew Opus setup
- add README examples for forcing --device mps in server and offline mode

## Notes
- this keeps the change small and focused around existing MPS-aware code paths
- README now reflects the current device-selection behavior more clearly