### PR TITLE
fix(server): prevent path traversal via voice_prompt query parameter

### DIFF
--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -152,7 +152,18 @@ class ServerState:
             voice_prompt_filename = request.query["voice_prompt"]
             requested_voice_prompt_path = None
             if voice_prompt_filename is not None:
+                # Sanitize: use only the basename to prevent path traversal (CWE-22)
+                voice_prompt_filename = os.path.basename(voice_prompt_filename)
+                if not voice_prompt_filename:
+                    raise ValueError("Invalid voice prompt filename")
                 requested_voice_prompt_path = os.path.join(self.voice_prompt_dir, voice_prompt_filename)
+                # Verify resolved path is within the allowed directory
+                resolved = os.path.realpath(requested_voice_prompt_path)
+                allowed_dir = os.path.realpath(self.voice_prompt_dir)
+                if not resolved.startswith(allowed_dir + os.sep) and resolved != allowed_dir:
+                    raise ValueError(
+                        f"Voice prompt path escapes the allowed directory"
+                    )
             # If the voice prompt file does not exist, find a valid (s0) voiceprompt file in the directory
             if requested_voice_prompt_path is None or not os.path.exists(requested_voice_prompt_path):
                 raise FileNotFoundError(


### PR DESCRIPTION
## Vulnerability Summary

The WebSocket endpoint `/api/chat` in `moshi/moshi/server.py` is vulnerable to path traversal (CWE-22) via the `voice_prompt` query parameter. An attacker can supply a crafted filename containing directory traversal sequences (e.g., `../../../etc/passwd`) to read or load arbitrary files from the server's filesystem.

**Affected code** (`server.py`, line 152):

```python
voice_prompt_filename = request.query["voice_prompt"]
# ...
requested_voice_prompt_path = os.path.join(self.voice_prompt_dir, voice_prompt_filename)
```

The `voice_prompt_filename` value is taken directly from the query string and passed to `os.path.join` without any sanitization. The resulting path is then used to load the file via `torch.load()` (for `.pt` files) or `load_audio()`, meaning an attacker can force the server to deserialize arbitrary PyTorch files or read arbitrary audio files from anywhere on disk.

**Severity:** High. `torch.load()` uses pickle deserialization under the hood, so loading an attacker-controlled `.pt` file can lead to **arbitrary code execution**.

## Proof of Concept

When the server is running with `--voice-prompt-dir /app/voices`:

```bash
# Connect to the WebSocket with a traversed voice_prompt path
# This causes the server to load /etc/passwd instead of a file in the voices directory
python3 -c "
import asyncio, aiohttp

async def exploit():
    async with aiohttp.ClientSession() as session:
        url = 'ws://TARGET:8998/api/chat?voice_prompt=../../../etc/passwd&text_prompt='
        async with session.ws_connect(url) as ws:
            print('Connected — server attempted to load traversed path')

asyncio.run(exploit())
"
```

For RCE via pickle deserialization, an attacker could place a malicious `.pt` file at a known path and reference it:

```bash
# voice_prompt=../../../tmp/malicious.pt
# torch.load() will unpickle the file, executing arbitrary Python code
```

The `/api/chat` endpoint has no authentication, so any client with network access can exploit this. While the server defaults to `localhost` binding, users commonly deploy with `--host 0.0.0.0`, exposing it to the network.

## Fix Description

This patch adds two layers of defense:

1. **`os.path.basename()`** strips any directory components from the user-supplied filename, so `../../../etc/passwd` becomes just `passwd`.

2. **`os.path.realpath()` containment check** resolves symlinks and verifies the final path is within the configured `voice_prompt_dir`. This guards against symlink-based bypasses.

If either check fails, a `ValueError` is raised before any file I/O occurs.

## Testing

- Verified that traversal payloads (`../../../etc/passwd`, `..%2f..%2f`, `....//....//`) are all neutralized by `os.path.basename()` — the resulting path stays within the allowed directory.
- Verified that legitimate voice prompt filenames (e.g., `voice1.pt`) continue to resolve correctly.
- Confirmed the fix does not change behavior for the fallback case where `voice_prompt` is not found (the existing `FileNotFoundError` still fires).

## Adversarial Review

Before submitting, we considered whether existing protections would prevent exploitation. The server has no authentication middleware, no input validation on query parameters, and `os.path.join` does not sanitize traversal sequences. The default `localhost` binding reduces exposure but is not a security control — deployment guides and common usage patterns (`--host 0.0.0.0`) routinely override it. The `torch.load()` sink makes this particularly dangerous since it enables code execution, not just file reads.