### PR TITLE
GB10 real-time serving: opt-in quantization + serve-path optimizations (2.2x: 101.7 -> 46.5 ms/frame)

### DIFF
--- a/moshi/moshi/fp8_quantize.py
+++ b/moshi/moshi/fp8_quantize.py
@@ -1,0 +1,244 @@
+"""FP8 dynamic quantization for PersonaPlex/Moshi.
+
+Usage:
+    from moshi.fp8_quantize import quantize_model, free_bf16_inproj
+
+    lm = loaders.get_moshi_lm(...)
+    quantize_model(lm)       # Quantize weights + patch forward paths
+    # ... warmup ...
+    free_bf16_inproj(lm)     # Free original bf16 in_proj copies
+
+Replaces nn.Linear weights with FP8 (float8_e4m3fn) and patches the
+gating/attention forward paths to use torch._scaled_mm for native FP8 GEMM.
+
+Benchmarked results:
+    - Jetson Thor:  114ms → 74ms lm_step (1.54x), 16.7 → 11.2 GB
+    - DGX Spark:    95.7ms → 70ms lm_step (1.37x), 18.8 → 11.0 GB
+"""
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import logging
+import types
+
+logger = logging.getLogger(__name__)
+
+
+def fp8_linear(x, weight_fp8, weight_scale, bias=None):
+    """FP8 GEMM with dynamic per-tensor input scaling."""
+    orig_shape = x.shape
+    in_features = weight_fp8.shape[1]
+    out_features = weight_fp8.shape[0]
+    x_2d = x.reshape(-1, in_features)
+
+    x_amax = x_2d.abs().amax()
+    x_scale = (x_amax / 448.0).clamp(min=1e-12)
+    x_fp8 = (x_2d / x_scale).to(torch.float8_e4m3fn)
+
+    out = torch._scaled_mm(
+        x_fp8, weight_fp8.t(),
+        scale_a=x_scale.float().view(1),
+        scale_b=weight_scale,
+        out_dtype=torch.bfloat16
+    )
+
+    if bias is not None:
+        out = out + bias
+    return out.reshape(*orig_shape[:-1], out_features)
+
+
+# ============================================================================
+# Module-level forward patch for nn.Linear
+# ============================================================================
+
+def _fp8_forward(self, x):
+    """Patched nn.Linear.forward using dynamic FP8."""
+    return fp8_linear(x, self.weight, self.weight_scale, self.bias)
+
+
+# ============================================================================
+# Gating forward patch (ActivationGating uses F.linear, not nn.Linear.forward)
+# ============================================================================
+
+def _make_gating_forward():
+    def gating_forward_fp8(self, x):
+        lin_in = self.linear_in
+        lin_out = self.linear_out
+        if getattr(lin_in, '_is_fp8', False):
+            x = fp8_linear(x, lin_in.weight, lin_in.weight_scale)
+        else:
+            x = F.linear(x, lin_in.weight)
+        B, T, _ = x.shape
+        x = x.view(B, T, 2, -1)
+        x = self.activation(x[..., 0, :]) * x[..., 1, :]
+        if getattr(lin_out, '_is_fp8', False):
+            x = fp8_linear(x, lin_out.weight, lin_out.weight_scale)
+        else:
+            x = F.linear(x, lin_out.weight)
+        return x
+    return gating_forward_fp8
+
+
+# ============================================================================
+# Attention forward patch (in_proj_weight is bare nn.Parameter, not nn.Linear)
+# ============================================================================
+
+def _make_attn_forward():
+    from einops import rearrange as _rearrange
+
+    def attn_forward_fp8(self, query, key, value):
+        import moshi.modules.transformer as tf_mod
+
+        state = self._streaming_state
+        T = query.shape[1]
+
+        if state is None:
+            offset = torch.zeros(1, device=query.device, dtype=torch.long)
+            offset_cpu = 0
+        else:
+            offset = state.offset
+            offset_cpu = state.offset_cpu
+
+        if self.weights_per_step:
+            projected = tf_mod.multi_linear(
+                self.weights_per_step, self.in_proj_weight, query, offset_cpu
+            )
+        else:
+            if getattr(self, '_in_proj_fp8', False):
+                projected = fp8_linear(query, self._in_proj_fp8_weight, self._in_proj_scale)
+            else:
+                projected = F.linear(query, self.in_proj_weight)
+
+        q, k, v = _rearrange(
+            projected, "b t (p h d) -> p b h t d", p=3, h=self.num_heads
+        )
+
+        if self.rope:
+            q, k = self.rope(q, k, offset, time_before_heads=False)
+
+        k, v, pos_k = self._complete_kv(k, v)
+        if self.causal:
+            pos_k = pos_k.view(1, -1)
+            pos_q = offset + torch.arange(
+                T, device=query.device, dtype=torch.long
+            ).view(-1, 1)
+            delta = pos_q - pos_k
+            attn_bias = (pos_k >= 0) & (delta >= 0)
+            if self.context is not None:
+                attn_bias = attn_bias & (delta < self.context)
+        else:
+            attn_bias = None
+        x = F.scaled_dot_product_attention(q, k, v, attn_bias, dropout_p=0.0)
+
+        x = _rearrange(x, "b h t d -> b t (h d)")
+        if self.weights_per_step:
+            x = tf_mod.multi_linear(
+                self.weights_per_step, self.out_proj.weight, x, offset_cpu
+            )
+        else:
+            out_proj = self.out_proj
+            if getattr(out_proj, '_is_fp8', False):
+                x = fp8_linear(x, out_proj.weight, out_proj.weight_scale)
+            else:
+                x = out_proj(x)
+        if state is not None:
+            state.offset.add_(T)
+            state.offset_cpu += T
+        return x
+
+    return attn_forward_fp8
+
+
+# ============================================================================
+# Weight quantization
+# ============================================================================
+
+def quantize_linear_fp8(module):
+    """Quantize a single nn.Linear to FP8 in-place."""
+    w = module.weight.data
+    amax = w.abs().amax()
+    scale = (amax / 448.0).clamp(min=1e-12)
+    module.weight = nn.Parameter(
+        (w / scale).to(torch.float8_e4m3fn), requires_grad=False
+    )
+    module.register_buffer('weight_scale', scale.float().view(1))
+    module._is_fp8 = True
+    module.forward = types.MethodType(_fp8_forward, module)
+
+
+def quantize_model(model, min_features=512):
+    """Quantize all large Linear layers in the model to FP8.
+
+    Patches ActivationGating and StreamingMultiheadAttention forward methods
+    to use FP8 GEMM via torch._scaled_mm.
+
+    Skips depformer self_attn (matrices too small — overhead > savings).
+    """
+    import moshi.modules.gating as gating_mod
+    import moshi.modules.transformer as tf_mod
+
+    gating_mod.ActivationGating.forward = _make_gating_forward()
+    tf_mod.StreamingMultiheadAttention.forward = _make_attn_forward()
+
+    linear_count = 0
+    for name, module in list(model.named_modules()):
+        if isinstance(module, nn.Linear):
+            if module.in_features < min_features and module.out_features < min_features:
+                continue
+            if module.weight.ndim > 2:
+                continue
+            # Skip depformer self_attn — per-step slices too small for FP8 benefit
+            if 'depformer' in name and 'self_attn' in name:
+                continue
+            quantize_linear_fp8(module)
+            linear_count += 1
+
+    # Quantize bare in_proj_weight parameters on main transformer attention
+    inproj_count = 0
+    for name, module in list(model.named_modules()):
+        if isinstance(module, tf_mod.StreamingMultiheadAttention):
+            if 'depformer' in name:
+                continue
+            if module.weights_per_step:
+                continue
+            w = module.in_proj_weight.data
+            if w.ndim != 2:
+                continue
+            amax = w.abs().amax()
+            scale = (amax / 448.0).clamp(min=1e-12)
+            module.register_buffer('_in_proj_fp8_weight',
+                (w / scale).to(torch.float8_e4m3fn))
+            module._in_proj_scale = scale.float().view(1)
+            module._in_proj_fp8 = True
+            inproj_count += 1
+
+    logger.info(f"[FP8] Quantized {linear_count} Linear + {inproj_count} in_proj_weight")
+    logger.info(f"[FP8] GPU memory: {torch.cuda.memory_allocated() / 1e9:.2f} GB")
+    return model
+
+
+# ============================================================================
+# Cleanup — free original bf16 copies after CUDA graph warmup
+# ============================================================================
+
+def free_bf16_inproj(model):
+    """Free bf16 in_proj_weight copies after warmup (KV cache already allocated).
+
+    Call this after state.warmup() — the CUDA graph has captured the FP8 path,
+    so the original bf16 weights are no longer needed.
+    """
+    import moshi.modules.transformer as tf_mod
+    freed = 0
+    for name, module in model.named_modules():
+        if isinstance(module, tf_mod.StreamingMultiheadAttention):
+            if getattr(module, '_in_proj_fp8', False):
+                sz = module.in_proj_weight.numel() * module.in_proj_weight.element_size()
+                module.in_proj_weight = nn.Parameter(
+                    torch.empty(0, dtype=torch.bfloat16, device=module.in_proj_weight.device),
+                    requires_grad=False
+                )
+                freed += sz
+    if freed > 0:
+        torch.cuda.empty_cache()
+        logger.info(f"[FP8] Freed {freed/1e9:.2f} GB bf16 in_proj_weight copies")
+        logger.info(f"[FP8] GPU memory after cleanup: {torch.cuda.memory_allocated() / 1e9:.2f} GB")

--- a/moshi/moshi/models/lm.py
+++ b/moshi/moshi/models/lm.py
@@ -176,6 +176,8 @@ def encode_from_sphn(mimi, samples, max_batch=sys.maxsize):
             break
 
         batch = torch.cat(current_batch, dim=0)  # shape: (B, C, T)
+        model_dtype = next(mimi.parameters()).dtype
+        batch = batch.to(dtype=model_dtype)
         encoded = mimi.encode(batch)  # shape: (B, K, F)
         separated = torch.unbind(encoded, dim=0)  # shape: (K, F)
         reshaped = [x.unsqueeze(0) for x in separated]  # shape: (1, K, F)

--- a/moshi/moshi/models/lm.py
+++ b/moshi/moshi/models/lm.py
@@ -663,6 +663,7 @@ class LMGen(StreamingModule[_LMGenState]):
         save_voice_prompt_embeddings: bool = False,
         sample_rate: int = 32000,
         frame_rate: int = FRAME_RATE_HZ,
+        depformer_early_exit: Optional[int] = None,
     ):
         assert not lm_model.training, "generation shouldn't be used in training mode."
         super().__init__()
@@ -695,6 +696,20 @@ class LMGen(StreamingModule[_LMGenState]):
         self.delays_cuda = torch.tensor(
             lm_model.delays, device=lm_model.device, dtype=torch.long
         )
+        self.depformer_early_exit = depformer_early_exit
+        if depformer_early_exit is not None:
+            # The serve stack decodes agent audio from codebooks 1..8, so at
+            # least 8 depformer steps must run. Codebooks beyond the exit
+            # point are only skippable because every step of the serve flow
+            # (warmup, voice/text prompts, streaming) provides the user-side
+            # tokens, which overwrite the sampled values in the cache.
+            assert 8 <= depformer_early_exit <= lm_model.dep_q, (
+                f"depformer_early_exit must be in [8, {lm_model.dep_q}]"
+            )
+            assert not return_logits and not report_loss, (
+                "depformer_early_exit is incompatible with "
+                "return_logits/report_loss"
+            )
         self.save_voice_prompt_embeddings = save_voice_prompt_embeddings
         self.voice_prompt_audio: Optional[torch.Tensor] = None
         self.voice_prompt_cache: Optional[torch.Tensor] = None
@@ -819,6 +834,12 @@ class LMGen(StreamingModule[_LMGenState]):
         -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | tuple[torch.Tensor, dict[str, torch.Tensor]]:
         state = self._streaming_state
         lm_model = self.lm_model
+        if self.depformer_early_exit is not None and input_tokens is None:
+            raise RuntimeError(
+                "depformer_early_exit requires input_tokens (user audio codes) "
+                "to be provided on every step: the skipped codebooks are only "
+                "safe to omit when provided tokens overwrite them."
+            )
         prepared_inputs = self.prepare_step_input(
             input_tokens, moshi_tokens, text_token,
         )
@@ -1141,8 +1162,11 @@ class LMGen(StreamingModule[_LMGenState]):
         depformer_tokens: list[torch.Tensor] = []
         depformer_logits: list[torch.Tensor] = []
         assert not lm_model.depformer.is_streaming
+        n_steps = lm_model.dep_q
+        if self.depformer_early_exit is not None:
+            n_steps = min(self.depformer_early_exit, lm_model.dep_q)
         with lm_model.depformer.streaming(B):
-            for cb_index in range(lm_model.dep_q):
+            for cb_index in range(n_steps):
                 input_ = prev_token[:, None, None]
                 logits = lm_model.forward_depformer(cb_index, input_, transformer_out)
                 if self.return_logits:
@@ -1165,6 +1189,14 @@ class LMGen(StreamingModule[_LMGenState]):
                 )
                 depformer_tokens.append(next_token)
 
+        if len(depformer_tokens) < lm_model.dep_q:
+            # Early exit: pad the skipped codebooks with zero_token_id (-1,
+            # "no input"). These values never reach the cache in the serve
+            # flow because the corresponding channels are always provided.
+            pad = torch.full_like(depformer_tokens[0], lm_model.zero_token_id)
+            depformer_tokens.extend(
+                [pad] * (lm_model.dep_q - len(depformer_tokens))
+            )
         assert len(depformer_tokens) == lm_model.dep_q, (
             len(depformer_tokens),
             lm_model.dep_q,

--- a/moshi/moshi/models/loaders.py
+++ b/moshi/moshi/models/loaders.py
@@ -252,6 +252,19 @@ def get_moshi_lm(
 
     # Assign weights to target device
     dev = torch.device(device) if isinstance(device, str) else device
+
+    # Patch 3: materialize any model parameters still absent from the
+    # checkpoint. The model is initialized on the meta device, so a key that
+    # is neither in the checkpoint nor covered by the patches above would
+    # survive load_state_dict(strict=False, assign=True) as a meta tensor and
+    # crash the final .to() with "Cannot copy out of meta tensor". This
+    # happens e.g. for depformer_emb.7 when expanding a base Moshi dep_q=8
+    # checkpoint to dep_q=16 (indices 8..15 are backfilled from 0..7, but
+    # index 7 itself does not exist in the checkpoint). Zero-init and warn.
+    for name, tensor in model_sd.items():
+        if name not in state_dict:
+            print(f"Zero-initializing key missing from checkpoint: {name}")
+            state_dict[name] = torch.zeros(tensor.shape, dtype=dtype, device=dev)
     for key in state_dict:
         state_dict[key] = state_dict[key].to(device=dev, dtype=dtype)
     

--- a/moshi/moshi/offline.py
+++ b/moshi/moshi/offline.py
@@ -90,35 +90,39 @@ def wrap_with_system_tags(text: str) -> str:
     return f"<system> {cleaned} <system>"
 
 
-def warmup(mimi: MimiModel, other_mimi: MimiModel, lm_gen: LMGen, device: str, frame_size: int):
+def warmup(mimi: MimiModel, other_mimi: Optional[MimiModel], lm_gen: LMGen, device: str, frame_size: int):
     """Run a short warmup loop to initialize CUDA graphs and streaming state.
 
     Replicates the same warmup behavior as server.py: zeros → encode → LMGen.step → decode.
     """
+    wdtype = next(mimi.parameters()).dtype
     for _ in range(4):
-        chunk = torch.zeros(1, 1, frame_size, dtype=torch.float32, device=device)
+        chunk = torch.zeros(1, 1, frame_size, dtype=wdtype, device=device)
         codes = mimi.encode(chunk)
-        _ = other_mimi.encode(chunk)
+        if other_mimi is not None:
+            _ = other_mimi.encode(chunk)
         for c in range(codes.shape[-1]):
             tokens = lm_gen.step(codes[:, :, c : c + 1])
             if tokens is None:
                 continue
             # Decode agent audio channels to ensure decode graphs/states are primed
             _ = mimi.decode(tokens[:, 1:9])
-            _ = other_mimi.decode(tokens[:, 1:9])
+            if other_mimi is not None:
+                _ = other_mimi.decode(tokens[:, 1:9])
     if torch.cuda.is_available():
         torch.cuda.synchronize()
 
 
-def decode_tokens_to_pcm(mimi: MimiModel, other_mimi: MimiModel, lm_gen: LMGen, tokens: torch.Tensor) -> np.ndarray:
+def decode_tokens_to_pcm(mimi: MimiModel, other_mimi: Optional[MimiModel], lm_gen: LMGen, tokens: torch.Tensor) -> np.ndarray:
     """Decode a single step of model tokens to PCM using Mimi.
 
     tokens is shaped [B, dep_q+1, 1]; channels 1..dep_q are the agent audio codebooks.
     Returns a 1D float32 numpy array (mono) for the current frame.
     """
     pcm = mimi.decode(tokens[:, 1:9])
-    _ = other_mimi.decode(tokens[:, 1:9])
-    pcm = pcm.detach().cpu().numpy()[0, 0]
+    if other_mimi is not None:
+        _ = other_mimi.decode(tokens[:, 1:9])
+    pcm = pcm.float().detach().cpu().numpy()[0, 0]
     return pcm
 
 
@@ -170,6 +174,8 @@ def run_inference(
     save_voice_prompt_embeddings: bool,
     cpu_offload: bool = False,
     dep_q_exit: Optional[int] = None,
+    skip_other_mimi: bool = False,
+    mimi_fp16: bool = False,
 ):
     """Run offline inference using an input WAV as the user-side stream.
 
@@ -192,7 +198,16 @@ def run_inference(
     if mimi_weight is None:
         mimi_weight = hf_hub_download(hf_repo, loaders.MIMI_NAME)  # type: ignore
     mimi = loaders.get_mimi(mimi_weight, device)
-    other_mimi = loaders.get_mimi(mimi_weight, device)
+    # The second mimi stream is pure discarded work in this path (its
+    # encode/decode outputs are assigned to _ and its state is read
+    # nowhere; same in server.py lines 123/129/225/232).
+    other_mimi = None if skip_other_mimi else loaders.get_mimi(mimi_weight, device)
+    if mimi_fp16:
+        mimi = mimi.half()
+        mimi.torch_compile_encoder_decoder = True  # unlock torch_compile_lazy
+        if other_mimi is not None:
+            other_mimi = other_mimi.half()
+            other_mimi.torch_compile_encoder_decoder = True
     log("info", "mimi loaded")
 
     # 2) Load tokenizer
@@ -226,7 +241,8 @@ def run_inference(
     )
     # Keep models in streaming mode similar to the server
     mimi.streaming_forever(1)
-    other_mimi.streaming_forever(1)
+    if other_mimi is not None:
+        other_mimi.streaming_forever(1)
     lm_gen.streaming_forever(1)
 
     # 5) Warmup
@@ -250,7 +266,8 @@ def run_inference(
     #    - Text prompt injection
     #    - Final audio silence
     mimi.reset_streaming()
-    other_mimi.reset_streaming()
+    if other_mimi is not None:
+        other_mimi.reset_streaming()
     lm_gen.reset_streaming()
     lm_gen.step_system_prompts(mimi)
     # Reset mimi streaming after voice prompt encoding
@@ -383,11 +400,21 @@ def main():
                         help="Offload LM model layers to CPU when GPU memory is insufficient. "
                              "Requires 'accelerate' package.")
     parser.add_argument("--seed", type=int, default=-1, help="Seed for reproducibility (-1 disables)")
+    parser.add_argument("--skip-other-mimi", action="store_true",
+                        help="Skip the second mimi stream (its outputs are discarded in this path)")
+    parser.add_argument("--mimi-fp16", action="store_true",
+                        help="Run mimi in fp16 with its torch.compile path enabled")
     parser.add_argument("--dep-q-exit", type=int, default=0,
                         help="Stop the depformer after N steps (>=8). Safe in the serve flow "
                              "because user-side codebooks are always provided.")
 
     args = parser.parse_args()
+    if args.mimi_fp16:
+        import importlib.util
+        if importlib.util.find_spec("triton") is None:
+            raise RuntimeError(
+                "--mimi-fp16 uses torch.compile on CUDA, which requires "
+                "Triton; install it with `pip install triton`.")
 
     # If --voice-prompt-dir is omitted, voices.tgz is downloaded from HF and extracted.
     voice_prompt_dir = _get_voice_prompt_dir(
@@ -430,6 +457,8 @@ def main():
             save_voice_prompt_embeddings=False,
             cpu_offload=args.cpu_offload,
             dep_q_exit=args.dep_q_exit if args.dep_q_exit > 0 else None,
+            skip_other_mimi=args.skip_other_mimi,
+            mimi_fp16=args.mimi_fp16,
         )
 
 

--- a/moshi/moshi/offline.py
+++ b/moshi/moshi/offline.py
@@ -176,6 +176,7 @@ def run_inference(
     dep_q_exit: Optional[int] = None,
     skip_other_mimi: bool = False,
     mimi_fp16: bool = False,
+    fp8: bool = False,
 ):
     """Run offline inference using an input WAV as the user-side stream.
 
@@ -221,6 +222,20 @@ def run_inference(
         moshi_weight = hf_hub_download(hf_repo, loaders.MOSHI_NAME)  # type: ignore
     lm = loaders.get_moshi_lm(moshi_weight, device=device, cpu_offload=cpu_offload)
     lm.eval()
+    if fp8:
+        if not torch.cuda.is_available():
+            raise RuntimeError("--fp8 requires a CUDA device.")
+        cc = torch.cuda.get_device_capability()
+        if cc < (8, 9):
+            raise RuntimeError(
+                f"--fp8 requires compute capability >= 8.9 for FP8 "
+                f"torch._scaled_mm (found sm_{cc[0]}{cc[1]}).")
+        if not hasattr(torch, "_scaled_mm"):
+            raise RuntimeError(
+                "--fp8 requires torch._scaled_mm (torch >= 2.2 CUDA build).")
+        from .fp8_quantize import quantize_model
+        log("info", "applying FP8 quantization")
+        quantize_model(lm)
     log("info", "moshi loaded")
 
     # 4) Construct LMGen like server.py's ServerState does
@@ -248,6 +263,9 @@ def run_inference(
     # 5) Warmup
     log("info", "warming up the model")
     warmup(mimi, other_mimi, lm_gen, device, frame_size)
+    if fp8:
+        from .fp8_quantize import free_bf16_inproj
+        free_bf16_inproj(lm)
 
     # 6) Prompt configuration (text + voice)
     # System text tokens (k=0) and agent voice-prompt audio (k=1..dep_q) are forced
@@ -400,6 +418,8 @@ def main():
                         help="Offload LM model layers to CPU when GPU memory is insufficient. "
                              "Requires 'accelerate' package.")
     parser.add_argument("--seed", type=int, default=-1, help="Seed for reproducibility (-1 disables)")
+    parser.add_argument("--fp8", action="store_true",
+                        help="Quantize LM linears to FP8 (torch._scaled_mm; requires SM >= 89)")
     parser.add_argument("--skip-other-mimi", action="store_true",
                         help="Skip the second mimi stream (its outputs are discarded in this path)")
     parser.add_argument("--mimi-fp16", action="store_true",
@@ -459,6 +479,7 @@ def main():
             dep_q_exit=args.dep_q_exit if args.dep_q_exit > 0 else None,
             skip_other_mimi=args.skip_other_mimi,
             mimi_fp16=args.mimi_fp16,
+            fp8=args.fp8,
         )
 
 

--- a/moshi/moshi/offline.py
+++ b/moshi/moshi/offline.py
@@ -169,6 +169,7 @@ def run_inference(
     greedy: bool,
     save_voice_prompt_embeddings: bool,
     cpu_offload: bool = False,
+    dep_q_exit: Optional[int] = None,
 ):
     """Run offline inference using an input WAV as the user-side stream.
 
@@ -221,6 +222,7 @@ def run_inference(
         temp_text=temp_text,
         top_k=topk_audio,
         top_k_text=topk_text,
+        depformer_early_exit=dep_q_exit,
     )
     # Keep models in streaming mode similar to the server
     mimi.streaming_forever(1)
@@ -381,6 +383,9 @@ def main():
                         help="Offload LM model layers to CPU when GPU memory is insufficient. "
                              "Requires 'accelerate' package.")
     parser.add_argument("--seed", type=int, default=-1, help="Seed for reproducibility (-1 disables)")
+    parser.add_argument("--dep-q-exit", type=int, default=0,
+                        help="Stop the depformer after N steps (>=8). Safe in the serve flow "
+                             "because user-side codebooks are always provided.")
 
     args = parser.parse_args()
 
@@ -424,6 +429,7 @@ def main():
             greedy=greedy,
             save_voice_prompt_embeddings=False,
             cpu_offload=args.cpu_offload,
+            dep_q_exit=args.dep_q_exit if args.dep_q_exit > 0 else None,
         )
 
 

--- a/moshi/moshi/offline.py
+++ b/moshi/moshi/offline.py
@@ -464,6 +464,16 @@ def main():
     if args.fp8 and args.w8a16:
         parser.error("--fp8 and --w8a16 are mutually exclusive")
 
+    # GB10 discoverability hint: log-only, fires only when NO perf flag is
+    # active and only on sm_121-class devices; never changes behavior.
+    _perf_flags = (args.fast or args.fp8 or args.w8a16 or args.mimi_fp16
+                   or args.skip_other_mimi or args.dep_q_exit > 0)
+    if (not _perf_flags and torch.cuda.is_available()
+            and torch.cuda.get_device_capability() == (12, 1)):
+        log("info", "GB10-class device detected (sm_121): real-time "
+                    "performance requires opt-in flags; try --fast "
+                    "(see PR notes)")
+
     # If --voice-prompt-dir is omitted, voices.tgz is downloaded from HF and extracted.
     voice_prompt_dir = _get_voice_prompt_dir(
         args.voice_prompt_dir,

--- a/moshi/moshi/offline.py
+++ b/moshi/moshi/offline.py
@@ -177,6 +177,7 @@ def run_inference(
     skip_other_mimi: bool = False,
     mimi_fp16: bool = False,
     fp8: bool = False,
+    w8a16: bool = False,
 ):
     """Run offline inference using an input WAV as the user-side stream.
 
@@ -236,6 +237,10 @@ def run_inference(
         from .fp8_quantize import quantize_model
         log("info", "applying FP8 quantization")
         quantize_model(lm)
+    elif w8a16:
+        from .w8a16_quantize import quantize_model_w8a16
+        log("info", "applying w8a16 weight-only quantization")
+        quantize_model_w8a16(lm)
     log("info", "moshi loaded")
 
     # 4) Construct LMGen like server.py's ServerState does
@@ -420,6 +425,10 @@ def main():
     parser.add_argument("--seed", type=int, default=-1, help="Seed for reproducibility (-1 disables)")
     parser.add_argument("--fp8", action="store_true",
                         help="Quantize LM linears to FP8 (torch._scaled_mm; requires SM >= 89)")
+    parser.add_argument("--w8a16", action="store_true",
+                        help="Weight-only 8-bit LM quantization, bf16 compute (Triton GEMV); exclusive with --fp8")
+    parser.add_argument("--fast", action="store_true",
+                        help="Preset: --w8a16 --dep-q-exit 8 --skip-other-mimi --mimi-fp16")
     parser.add_argument("--skip-other-mimi", action="store_true",
                         help="Skip the second mimi stream (its outputs are discarded in this path)")
     parser.add_argument("--mimi-fp16", action="store_true",
@@ -435,6 +444,25 @@ def main():
             raise RuntimeError(
                 "--mimi-fp16 uses torch.compile on CUDA, which requires "
                 "Triton; install it with `pip install triton`.")
+    if args.fast:
+        import importlib.util
+        missing = []
+        if not torch.cuda.is_available():
+            missing.append("a CUDA device (required by --w8a16/--mimi-fp16)")
+        if importlib.util.find_spec("triton") is None:
+            missing.append("Triton (required by --w8a16's dequant GEMV and "
+                           "--mimi-fp16's torch.compile path)")
+        if missing:
+            raise RuntimeError(
+                "--fast cannot meet its performance contract; missing: "
+                + "; ".join(missing) + ". No silent degradation is "
+                "provided — run without --fast or install the prerequisite.")
+        args.w8a16 = True
+        args.dep_q_exit = args.dep_q_exit or 8
+        args.skip_other_mimi = True
+        args.mimi_fp16 = True
+    if args.fp8 and args.w8a16:
+        parser.error("--fp8 and --w8a16 are mutually exclusive")
 
     # If --voice-prompt-dir is omitted, voices.tgz is downloaded from HF and extracted.
     voice_prompt_dir = _get_voice_prompt_dir(
@@ -480,6 +508,7 @@ def main():
             skip_other_mimi=args.skip_other_mimi,
             mimi_fp16=args.mimi_fp16,
             fp8=args.fp8,
+            w8a16=args.w8a16,
         )
 
 

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -96,12 +96,13 @@ class ServerState:
 
     def __init__(self, mimi: MimiModel, other_mimi: MimiModel, text_tokenizer: sentencepiece.SentencePieceProcessor,
                  lm: LMModel, device: str | torch.device, voice_prompt_dir: str | None = None,
-                 save_voice_prompt_embeddings: bool = False):
+                 save_voice_prompt_embeddings: bool = False, fp8: bool = False):
         self.mimi = mimi
         self.other_mimi = other_mimi
         self.text_tokenizer = text_tokenizer
         self.device = device
         self.voice_prompt_dir = voice_prompt_dir
+        self._fp8 = fp8
         self.frame_size = int(self.mimi.sample_rate / self.mimi.frame_rate)
         self.lm_gen = LMGen(lm,
                             audio_silence_frame_cnt=int(0.5 * self.mimi.frame_rate),
@@ -112,21 +113,25 @@ class ServerState:
         )
         
         self.lock = asyncio.Lock()
+        # Pre-allocate pinned CPU buffer for non-blocking DtoH audio transfer
+        # mimi.decode output shape: [1, 1, 1920] (1920 samples per frame at 24kHz)
+        self._pinned_pcm = torch.empty(1920, dtype=torch.float32, pin_memory=True)
         self.mimi.streaming_forever(1)
         self.other_mimi.streaming_forever(1)
         self.lm_gen.streaming_forever(1)
     
     def warmup(self):
+        warmup_dtype = torch.float16 if self._fp8 else torch.float32
         for _ in range(4):
-            chunk = torch.zeros(1, 1, self.frame_size, dtype=torch.float32, device=self.device)
+            chunk = torch.zeros(1, 1, self.frame_size, dtype=warmup_dtype, device=self.device)
             codes = self.mimi.encode(chunk)
-            _ = self.other_mimi.encode(chunk)
+            # Skip other_mimi.encode — its output is always discarded
             for c in range(codes.shape[-1]):
                 tokens = self.lm_gen.step(codes[:, :, c: c + 1])
                 if tokens is None:
                     continue
                 _ = self.mimi.decode(tokens[:, 1:9])
-                _ = self.other_mimi.decode(tokens[:, 1:9])
+                # Skip other_mimi.decode — its output is always discarded
 
         if self.device.type == 'cuda':
             torch.cuda.synchronize()
@@ -203,6 +208,9 @@ class ServerState:
 
         async def opus_loop():
             all_pcm_data = None
+            _frame_count = 0
+            _profile_interval = 50  # log timing every 50 frames
+            _input_dtype = torch.float16 if self._fp8 else torch.float32
 
             while True:
                 if close:
@@ -216,22 +224,63 @@ class ServerState:
                 else:
                     all_pcm_data = np.concatenate((all_pcm_data, pcm))
                 while all_pcm_data.shape[-1] >= self.frame_size:
-                    be = time.time()
+                    _frame_count += 1
+                    _do_log = (_frame_count % _profile_interval == 1)
+                    _t0 = time.time()
+
                     chunk = all_pcm_data[: self.frame_size]
                     all_pcm_data = all_pcm_data[self.frame_size:]
                     chunk = torch.from_numpy(chunk)
-                    chunk = chunk.to(device=self.device)[None, None]
+                    chunk = chunk.to(device=self.device, dtype=_input_dtype)[None, None]
+
+                    if _do_log:
+                        torch.cuda.synchronize()
+                        _t1 = time.time()
+
                     codes = self.mimi.encode(chunk)
-                    _ = self.other_mimi.encode(chunk)
+                    # Skip other_mimi.encode — output always discarded (saves ~6ms)
+
+                    if _do_log:
+                        torch.cuda.synchronize()
+                        _t2 = time.time()
+
+                    _step_total = 0.0
+                    _decode_total = 0.0
+                    _n_codes = 0
                     for c in range(codes.shape[-1]):
+                        if _do_log:
+                            torch.cuda.synchronize()
+                            _ts0 = time.time()
+
                         tokens = self.lm_gen.step(codes[:, :, c: c + 1])
+
+                        if _do_log:
+                            torch.cuda.synchronize()
+                            _ts1 = time.time()
+                            _step_total += (_ts1 - _ts0)
+
                         if tokens is None:
                             continue
+                        _n_codes += 1
                         assert tokens.shape[1] == self.lm_gen.lm_model.dep_q + 1
+
+                        if _do_log:
+                            torch.cuda.synchronize()
+                            _td0 = time.time()
+
                         main_pcm = self.mimi.decode(tokens[:, 1:9])
-                        _ = self.other_mimi.decode(tokens[:, 1:9])
-                        main_pcm = main_pcm.cpu()
-                        opus_writer.append_pcm(main_pcm[0, 0].numpy())
+                        # Skip other_mimi.decode — output always discarded (saves ~4ms)
+
+                        if _do_log:
+                            torch.cuda.synchronize()
+                            _td1 = time.time()
+                            _decode_total += (_td1 - _td0)
+
+                        # Pinned memory DtoH transfer (saves ~2ms vs .cpu())
+                        main_pcm = main_pcm.float()
+                        self._pinned_pcm.copy_(main_pcm[0, 0], non_blocking=True)
+                        torch.cuda.current_stream().synchronize()
+                        opus_writer.append_pcm(self._pinned_pcm.numpy())
                         text_token = tokens[0, 0, 0].item()
                         if text_token not in (0, 3):
                             _text = self.text_tokenizer.id_to_piece(text_token)  # type: ignore
@@ -240,6 +289,19 @@ class ServerState:
                             await ws.send_bytes(msg)
                         else:
                             text_token_map = ['EPAD', 'BOS', 'EOS', 'PAD']
+
+                    _t3 = time.time()
+                    _total_ms = (_t3 - _t0) * 1000
+                    if _do_log:
+                        _prep_ms = (_t1 - _t0) * 1000
+                        _encode_ms = (_t2 - _t1) * 1000
+                        _step_ms = _step_total * 1000
+                        _dec_ms = _decode_total * 1000
+                        _other_ms = _total_ms - _prep_ms - _encode_ms - _step_ms - _dec_ms
+                        logger.info(f"frame={_frame_count} total={_total_ms:.1f}ms | "
+                                    f"prep={_prep_ms:.1f} encode={_encode_ms:.1f} "
+                                    f"lm_step={_step_ms:.1f} decode={_dec_ms:.1f} "
+                                    f"other={_other_ms:.1f} codes={_n_codes}")
 
         async def send_loop():
             while True:
@@ -390,6 +452,11 @@ def main():
             "that contains valid key.pem and cert.pem files"
         )
     )
+    parser.add_argument(
+        "--fp8",
+        action="store_true",
+        help="Quantize LM weights to FP8 for ~1.4x faster inference (requires SM >= 89)"
+    )
 
     args = parser.parse_args()
     args.voice_prompt_dir = _get_voice_prompt_dir(
@@ -433,7 +500,15 @@ def main():
         args.mimi_weight = hf_hub_download(args.hf_repo, loaders.MIMI_NAME)
     mimi = loaders.get_mimi(args.mimi_weight, args.device)
     other_mimi = loaders.get_mimi(args.mimi_weight, args.device)
-    logger.info("mimi loaded")
+    if args.fp8:
+        # FP16 mimi + torch.compile for faster encode/decode (~3ms saved)
+        mimi = mimi.half()
+        other_mimi = other_mimi.half()
+        mimi.torch_compile_encoder_decoder = True
+        mimi = torch.compile(mimi)
+        logger.info("mimi loaded (FP16 + compiled)")
+    else:
+        logger.info("mimi loaded")
 
     if args.tokenizer is None:
         args.tokenizer = hf_hub_download(args.hf_repo, loaders.TEXT_TOKENIZER_NAME)
@@ -444,6 +519,11 @@ def main():
         args.moshi_weight = hf_hub_download(args.hf_repo, loaders.MOSHI_NAME)
     lm = loaders.get_moshi_lm(args.moshi_weight, device=args.device, cpu_offload=args.cpu_offload)
     lm.eval()
+    if args.fp8:
+        from .fp8_quantize import quantize_model
+        logger.info("applying FP8 quantization...")
+        quantize_model(lm)
+        logger.info("FP8 quantization complete")
     logger.info("moshi loaded")
     state = ServerState(
         mimi=mimi,
@@ -453,9 +533,13 @@ def main():
         device=args.device,
         voice_prompt_dir=args.voice_prompt_dir,
         save_voice_prompt_embeddings=False,
+        fp8=args.fp8,
     )
     logger.info("warming up the model")
     state.warmup()
+    if args.fp8:
+        from .fp8_quantize import free_bf16_inproj
+        free_bf16_inproj(lm)
     app = web.Application()
     app.router.add_get("/api/chat", state.handle_chat)
     if static_path is not None:

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -520,6 +520,14 @@ def main():
     # No worries about double-counting since config.json will be cached the second time
     hf_hub_download(args.hf_repo, "config.json")
 
+    _perf_flags = (args.fp8 or args.skip_other_mimi or args.mimi_fp16
+                   or args.pinned_io)
+    if (not _perf_flags and torch.cuda.is_available()
+            and torch.cuda.get_device_capability() == (12, 1)):
+        logger.info("GB10-class device detected (sm_121): real-time "
+                    "performance requires opt-in flags; try the flags in "
+                    "the GB10 PR notes (e.g. --fp8/--skip-other-mimi)")
+
     logger.info("loading mimi")
     if args.mimi_weight is None:
         args.mimi_weight = hf_hub_download(args.hf_repo, loaders.MIMI_NAME)

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -99,7 +99,7 @@ class ServerState:
     def __init__(self, mimi: MimiModel, other_mimi: tp.Optional[MimiModel], text_tokenizer: sentencepiece.SentencePieceProcessor,
                  lm: LMModel, device: str | torch.device, voice_prompt_dir: str | None = None,
                  save_voice_prompt_embeddings: bool = False, fp8: bool = False,
-                 pinned_io: bool = False):
+                 pinned_io: bool = False, dep_q_exit: int = 0):
         self.mimi = mimi
         self.other_mimi = other_mimi
         self.text_tokenizer = text_tokenizer
@@ -113,6 +113,7 @@ class ServerState:
                             device=device,
                             frame_rate=self.mimi.frame_rate,
                             save_voice_prompt_embeddings=save_voice_prompt_embeddings,
+                            depformer_early_exit=dep_q_exit,
         )
         
         self.lock = asyncio.Lock()
@@ -482,8 +483,37 @@ def main():
     parser.add_argument(
         "--pinned-io", action="store_true",
         help="Use a pinned CPU buffer for DtoH audio transfer")
+    parser.add_argument(
+        "--w8a16", action="store_true",
+        help="Weight-only 8-bit LM quantization, bf16 compute (Triton GEMV); exclusive with --fp8")
+    parser.add_argument(
+        "--fast", action="store_true",
+        help="Preset: --w8a16 --dep-q-exit 8 --skip-other-mimi --mimi-fp16")
+    parser.add_argument(
+        "--dep-q-exit", type=int, default=0,
+        help="Stop the depformer after N steps (>=8). Safe in the serve flow "
+             "because user-side codebooks are always provided.")
 
     args = parser.parse_args()
+    if args.fast:
+        import importlib.util
+        missing = []
+        if not torch.cuda.is_available():
+            missing.append("a CUDA device (required by --w8a16/--mimi-fp16)")
+        if importlib.util.find_spec("triton") is None:
+            missing.append("Triton (required by --w8a16's dequant GEMV and "
+                           "--mimi-fp16's torch.compile path)")
+        if missing:
+            raise RuntimeError(
+                "--fast cannot meet its performance contract; missing: "
+                + "; ".join(missing) + ". No silent degradation is "
+                "provided — run without --fast or install the prerequisite.")
+        args.w8a16 = True
+        args.dep_q_exit = args.dep_q_exit or 8
+        args.skip_other_mimi = True
+        args.mimi_fp16 = True
+    if args.fp8 and args.w8a16:
+        parser.error("--fp8 and --w8a16 are mutually exclusive")
     args.voice_prompt_dir = _get_voice_prompt_dir(
         args.voice_prompt_dir,
         args.hf_repo,
@@ -520,13 +550,13 @@ def main():
     # No worries about double-counting since config.json will be cached the second time
     hf_hub_download(args.hf_repo, "config.json")
 
-    _perf_flags = (args.fp8 or args.skip_other_mimi or args.mimi_fp16
-                   or args.pinned_io)
+    _perf_flags = (args.fast or args.fp8 or args.w8a16 or args.skip_other_mimi
+                   or args.mimi_fp16 or args.pinned_io or args.dep_q_exit > 0)
     if (not _perf_flags and torch.cuda.is_available()
             and torch.cuda.get_device_capability() == (12, 1)):
         logger.info("GB10-class device detected (sm_121): real-time "
-                    "performance requires opt-in flags; try the flags in "
-                    "the GB10 PR notes (e.g. --fp8/--skip-other-mimi)")
+                    "performance requires opt-in flags; try --fast "
+                    "(see the GB10 PR notes)")
 
     logger.info("loading mimi")
     if args.mimi_weight is None:
@@ -564,6 +594,11 @@ def main():
         logger.info("applying FP8 quantization...")
         quantize_model(lm)
         logger.info("FP8 quantization complete")
+    elif args.w8a16:
+        from .w8a16_quantize import quantize_model_w8a16
+        logger.info("applying w8a16 weight-only quantization...")
+        quantize_model_w8a16(lm)
+        logger.info("w8a16 quantization complete")
     logger.info("moshi loaded")
     state = ServerState(
         mimi=mimi,
@@ -575,6 +610,7 @@ def main():
         save_voice_prompt_embeddings=False,
         fp8=args.fp8,
         pinned_io=args.pinned_io,
+        dep_q_exit=args.dep_q_exit,
     )
     logger.info("warming up the model")
     state.warmup()

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -42,6 +42,8 @@ from huggingface_hub import hf_hub_download
 import numpy as np
 import sentencepiece
 import sphn
+import typing as tp
+
 import torch
 import random
 
@@ -94,9 +96,10 @@ class ServerState:
     lm_gen: LMGen
     lock: asyncio.Lock
 
-    def __init__(self, mimi: MimiModel, other_mimi: MimiModel, text_tokenizer: sentencepiece.SentencePieceProcessor,
+    def __init__(self, mimi: MimiModel, other_mimi: tp.Optional[MimiModel], text_tokenizer: sentencepiece.SentencePieceProcessor,
                  lm: LMModel, device: str | torch.device, voice_prompt_dir: str | None = None,
-                 save_voice_prompt_embeddings: bool = False, fp8: bool = False):
+                 save_voice_prompt_embeddings: bool = False, fp8: bool = False,
+                 pinned_io: bool = False):
         self.mimi = mimi
         self.other_mimi = other_mimi
         self.text_tokenizer = text_tokenizer
@@ -113,25 +116,30 @@ class ServerState:
         )
         
         self.lock = asyncio.Lock()
-        # Pre-allocate pinned CPU buffer for non-blocking DtoH audio transfer
+        # Optional pinned CPU buffer for non-blocking DtoH audio transfer
         # mimi.decode output shape: [1, 1, 1920] (1920 samples per frame at 24kHz)
-        self._pinned_pcm = torch.empty(1920, dtype=torch.float32, pin_memory=True)
+        self._pinned_pcm = (torch.empty(1920, dtype=torch.float32, pin_memory=True)
+                            if pinned_io else None)
         self.mimi.streaming_forever(1)
-        self.other_mimi.streaming_forever(1)
+        if self.other_mimi is not None:
+            self.other_mimi.streaming_forever(1)
         self.lm_gen.streaming_forever(1)
     
     def warmup(self):
-        warmup_dtype = torch.float16 if self._fp8 else torch.float32
+        # dtype follows mimi (fp32 stock; fp16 only under --mimi-fp16)
+        warmup_dtype = next(self.mimi.parameters()).dtype
         for _ in range(4):
             chunk = torch.zeros(1, 1, self.frame_size, dtype=warmup_dtype, device=self.device)
             codes = self.mimi.encode(chunk)
-            # Skip other_mimi.encode — its output is always discarded
+            if self.other_mimi is not None:
+                _ = self.other_mimi.encode(chunk)
             for c in range(codes.shape[-1]):
                 tokens = self.lm_gen.step(codes[:, :, c: c + 1])
                 if tokens is None:
                     continue
                 _ = self.mimi.decode(tokens[:, 1:9])
-                # Skip other_mimi.decode — its output is always discarded
+                if self.other_mimi is not None:
+                    _ = self.other_mimi.decode(tokens[:, 1:9])
 
         if self.device.type == 'cuda':
             torch.cuda.synchronize()
@@ -210,7 +218,7 @@ class ServerState:
             all_pcm_data = None
             _frame_count = 0
             _profile_interval = 50  # log timing every 50 frames
-            _input_dtype = torch.float16 if self._fp8 else torch.float32
+            _input_dtype = next(self.mimi.parameters()).dtype
 
             while True:
                 if close:
@@ -238,7 +246,9 @@ class ServerState:
                         _t1 = time.time()
 
                     codes = self.mimi.encode(chunk)
-                    # Skip other_mimi.encode — output always discarded (saves ~6ms)
+                    if self.other_mimi is not None:
+                        # Output always discarded; skippable via --skip-other-mimi (saves ~6ms)
+                        _ = self.other_mimi.encode(chunk)
 
                     if _do_log:
                         torch.cuda.synchronize()
@@ -269,18 +279,24 @@ class ServerState:
                             _td0 = time.time()
 
                         main_pcm = self.mimi.decode(tokens[:, 1:9])
-                        # Skip other_mimi.decode — output always discarded (saves ~4ms)
+                        if self.other_mimi is not None:
+                            # Output always discarded; skippable via --skip-other-mimi (saves ~4ms)
+                            _ = self.other_mimi.decode(tokens[:, 1:9])
 
                         if _do_log:
                             torch.cuda.synchronize()
                             _td1 = time.time()
                             _decode_total += (_td1 - _td0)
 
-                        # Pinned memory DtoH transfer (saves ~2ms vs .cpu())
-                        main_pcm = main_pcm.float()
-                        self._pinned_pcm.copy_(main_pcm[0, 0], non_blocking=True)
-                        torch.cuda.current_stream().synchronize()
-                        opus_writer.append_pcm(self._pinned_pcm.numpy())
+                        if self._pinned_pcm is not None:
+                            # Pinned memory DtoH transfer (saves ~2ms vs .cpu())
+                            main_pcm = main_pcm.float()
+                            self._pinned_pcm.copy_(main_pcm[0, 0], non_blocking=True)
+                            torch.cuda.current_stream().synchronize()
+                            opus_writer.append_pcm(self._pinned_pcm.numpy())
+                        else:
+                            main_pcm = main_pcm.float().cpu()
+                            opus_writer.append_pcm(main_pcm[0, 0].numpy())
                         text_token = tokens[0, 0, 0].item()
                         if text_token not in (0, 3):
                             _text = self.text_tokenizer.id_to_piece(text_token)  # type: ignore
@@ -457,6 +473,15 @@ def main():
         action="store_true",
         help="Quantize LM weights to FP8 for ~1.4x faster inference (requires SM >= 89)"
     )
+    parser.add_argument(
+        "--skip-other-mimi", action="store_true",
+        help="Skip the second mimi stream (its outputs are discarded in this serve path)")
+    parser.add_argument(
+        "--mimi-fp16", action="store_true",
+        help="Run mimi in fp16 with torch.compile (requires a working torch.compile backend)")
+    parser.add_argument(
+        "--pinned-io", action="store_true",
+        help="Use a pinned CPU buffer for DtoH audio transfer")
 
     args = parser.parse_args()
     args.voice_prompt_dir = _get_voice_prompt_dir(
@@ -499,11 +524,12 @@ def main():
     if args.mimi_weight is None:
         args.mimi_weight = hf_hub_download(args.hf_repo, loaders.MIMI_NAME)
     mimi = loaders.get_mimi(args.mimi_weight, args.device)
-    other_mimi = loaders.get_mimi(args.mimi_weight, args.device)
-    if args.fp8:
+    other_mimi = None if args.skip_other_mimi else loaders.get_mimi(args.mimi_weight, args.device)
+    if args.mimi_fp16:
         # FP16 mimi + torch.compile for faster encode/decode (~3ms saved)
         mimi = mimi.half()
-        other_mimi = other_mimi.half()
+        if other_mimi is not None:
+            other_mimi = other_mimi.half()
         mimi.torch_compile_encoder_decoder = True
         mimi = torch.compile(mimi)
         logger.info("mimi loaded (FP16 + compiled)")
@@ -520,6 +546,12 @@ def main():
     lm = loaders.get_moshi_lm(args.moshi_weight, device=args.device, cpu_offload=args.cpu_offload)
     lm.eval()
     if args.fp8:
+        if torch.cuda.is_available():
+            cc = torch.cuda.get_device_capability()
+            if cc < (8, 9):
+                raise SystemExit(
+                    f"--fp8 requires compute capability >= 8.9 for FP8 "
+                    f"torch._scaled_mm (found sm_{cc[0]}{cc[1]})")
         from .fp8_quantize import quantize_model
         logger.info("applying FP8 quantization...")
         quantize_model(lm)
@@ -534,6 +566,7 @@ def main():
         voice_prompt_dir=args.voice_prompt_dir,
         save_voice_prompt_embeddings=False,
         fp8=args.fp8,
+        pinned_io=args.pinned_io,
     )
     logger.info("warming up the model")
     state.warmup()

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -342,7 +342,8 @@ class ServerState:
             opus_writer = sphn.OpusStreamWriter(self.mimi.sample_rate)
             opus_reader = sphn.OpusStreamReader(self.mimi.sample_rate)
             self.mimi.reset_streaming()
-            self.other_mimi.reset_streaming()
+            if self.other_mimi is not None:
+                self.other_mimi.reset_streaming()
             self.lm_gen.reset_streaming()
             async def is_alive():
                 if close or ws.closed:

--- a/moshi/moshi/w8a16_quantize.py
+++ b/moshi/moshi/w8a16_quantize.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: MIT
+"""Weight-only 8-bit quantization (w8a16) scaffolding for PersonaPlex/Moshi.
+
+Weights are stored as float8_e4m3fn and dequantized before a bf16 matmul —
+activation precision is untouched (unlike the FP8 path, which also
+quantizes activations for torch._scaled_mm).
+
+Layer selection and forward-patching scaffolding (module walk,
+min_features gate, depformer-self_attn skip, bare in_proj handling,
+class-level gating/attention forward patches) is derived from
+fp8_quantize.py by amarrmb (github.com/amarrmb/personaplex), adapted to
+dispatch multiple quantization schemes per instance.
+
+This commit uses a naive dequantize-then-cuBLAS linear as a correctness
+baseline; the fused Triton dequant-in-register GEMV and per-channel
+scaling land in the follow-up commit.
+"""
+
+import logging
+import types
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+
+def w8a16_linear(x, w_fp8, scale, bias=None):
+    """Weight-only-8bit linear: dequantize to bf16, then cuBLAS.
+
+    Naive correctness baseline — streams 1 byte/weight from memory only
+    after the dequant materialization, so it is NOT faster than bf16 yet;
+    the fused Triton GEMV replaces this in the next commit.
+    """
+    w = (w_fp8.to(torch.float32) * scale).to(x.dtype)
+    return F.linear(x, w, bias)
+
+
+# ============================================================================
+# Forward patches (dispatch on instance flags; fp8-compatible, see module doc)
+# ============================================================================
+
+def _w8a16_forward(self, x):
+    return w8a16_linear(x, self.weight, self.w8a16_scale, self.bias)
+
+
+def _make_gating_forward():
+    from .fp8_quantize import fp8_linear
+
+    def _apply(lin, x):
+        # Per-instance dispatch: this class-level patch may be installed
+        # after fp8_quantize's, so it must recognize both schemes' markers.
+        if getattr(lin, "_is_w8a16", False):
+            return w8a16_linear(x, lin.weight, lin.w8a16_scale)
+        if getattr(lin, "_is_fp8", False):
+            return fp8_linear(x, lin.weight, lin.weight_scale)
+        return F.linear(x, lin.weight)
+
+    def gating_forward(self, x):
+        x = _apply(self.linear_in, x)
+        B, T, _ = x.shape
+        x = x.view(B, T, 2, -1)
+        x = self.activation(x[..., 0, :]) * x[..., 1, :]
+        return _apply(self.linear_out, x)
+
+    return gating_forward
+
+
+def _make_attn_forward():
+    from einops import rearrange as _rearrange
+    from .fp8_quantize import fp8_linear
+
+    def attn_forward(self, query, key, value):
+        import moshi.modules.transformer as tf_mod
+
+        state = self._streaming_state
+        T = query.shape[1]
+        if state is None:
+            offset = torch.zeros(1, device=query.device, dtype=torch.long)
+            offset_cpu = 0
+        else:
+            offset = state.offset
+            offset_cpu = state.offset_cpu
+
+        if self.weights_per_step:
+            projected = tf_mod.multi_linear(
+                self.weights_per_step, self.in_proj_weight, query, offset_cpu
+            )
+        elif getattr(self, "_in_proj_w8a16", False):
+            projected = w8a16_linear(query, self._in_proj_q_weight,
+                                     self._in_proj_q_scale)
+        elif getattr(self, "_in_proj_fp8", False):
+            projected = fp8_linear(query, self._in_proj_fp8_weight,
+                                   self._in_proj_scale)
+        else:
+            projected = F.linear(query, self.in_proj_weight)
+
+        q, k, v = _rearrange(
+            projected, "b t (p h d) -> p b h t d", p=3, h=self.num_heads
+        )
+        if self.rope:
+            q, k = self.rope(q, k, offset, time_before_heads=False)
+
+        k, v, pos_k = self._complete_kv(k, v)
+        if self.causal:
+            pos_k = pos_k.view(1, -1)
+            pos_q = offset + torch.arange(
+                T, device=query.device, dtype=torch.long
+            ).view(-1, 1)
+            delta = pos_q - pos_k
+            attn_bias = (pos_k >= 0) & (delta >= 0)
+            if self.context is not None:
+                attn_bias = attn_bias & (delta < self.context)
+        else:
+            attn_bias = None
+        x = F.scaled_dot_product_attention(q, k, v, attn_bias, dropout_p=0.0)
+
+        x = _rearrange(x, "b h t d -> b t (h d)")
+        if self.weights_per_step:
+            x = tf_mod.multi_linear(
+                self.weights_per_step, self.out_proj.weight, x, offset_cpu
+            )
+        else:
+            out_proj = self.out_proj
+            if getattr(out_proj, "_is_w8a16", False):
+                x = w8a16_linear(x, out_proj.weight, out_proj.w8a16_scale)
+            elif getattr(out_proj, "_is_fp8", False):
+                x = fp8_linear(x, out_proj.weight, out_proj.weight_scale)
+            else:
+                x = out_proj(x)
+        if state is not None:
+            state.offset.add_(T)
+            state.offset_cpu += T
+        return x
+
+    return attn_forward
+
+
+# ============================================================================
+# Weight quantization
+# ============================================================================
+
+def _quantize_weight(w):
+    """Per-tensor fp8e4m3 storage (as in fp8_quantize). Returns
+    (w_fp8, scale_fp32 scalar)."""
+    amax = w.abs().amax()
+    scale = (amax / 448.0).clamp(min=1e-12).float().view(1)
+    w_fp8 = (w.float() / scale).to(torch.float8_e4m3fn)
+    return w_fp8, scale
+
+
+def quantize_linear_w8a16(module):
+    w_fp8, scale = _quantize_weight(module.weight.data)
+    module.weight = nn.Parameter(w_fp8, requires_grad=False)
+    module.register_buffer("w8a16_scale", scale)
+    module._is_w8a16 = True
+    module.forward = types.MethodType(_w8a16_forward, module)
+
+
+def quantize_model_w8a16(model, min_features=512):
+    """Quantize all large Linear layers to weight-only fp8 (bf16 compute).
+
+    Coverage mirrors fp8_quantize.quantize_model: skips small linears and
+    depformer self_attn; also converts main-attention bare in_proj_weight.
+    """
+    import moshi.modules.gating as gating_mod
+    import moshi.modules.transformer as tf_mod
+
+    gating_mod.ActivationGating.forward = _make_gating_forward()
+    tf_mod.StreamingMultiheadAttention.forward = _make_attn_forward()
+
+    n_lin = 0
+    for name, module in list(model.named_modules()):
+        if isinstance(module, nn.Linear):
+            if module.in_features < min_features and module.out_features < min_features:
+                continue
+            if module.weight.ndim > 2:
+                continue
+            if "depformer" in name and "self_attn" in name:
+                continue
+            quantize_linear_w8a16(module)
+            n_lin += 1
+
+    n_inproj = 0
+    for name, module in list(model.named_modules()):
+        if isinstance(module, tf_mod.StreamingMultiheadAttention):
+            if "depformer" in name or module.weights_per_step:
+                continue
+            w = module.in_proj_weight.data
+            if w.ndim != 2:
+                continue
+            w_fp8, scale = _quantize_weight(w)
+            module.register_buffer("_in_proj_q_weight", w_fp8)
+            module.register_buffer("_in_proj_q_scale", scale)
+            module._in_proj_w8a16 = True
+            # free the bf16 copy immediately (kernel never reads it)
+            module.in_proj_weight = nn.Parameter(
+                torch.empty(0, dtype=w.dtype, device=w.device),
+                requires_grad=False,
+            )
+            n_inproj += 1
+
+    torch.cuda.empty_cache()
+    logger.info(f"[w8a16] Quantized {n_lin} Linear + {n_inproj} in_proj_weight")
+    logger.info(f"[w8a16] GPU memory: {torch.cuda.memory_allocated() / 1e9:.2f} GB")
+    return model

--- a/moshi/moshi/w8a16_quantize.py
+++ b/moshi/moshi/w8a16_quantize.py
@@ -1,19 +1,26 @@
 # SPDX-License-Identifier: MIT
-"""Weight-only 8-bit quantization (w8a16) scaffolding for PersonaPlex/Moshi.
+"""Weight-only 8-bit quantization (w8a16) for PersonaPlex/Moshi.
 
-Weights are stored as float8_e4m3fn and dequantized before a bf16 matmul —
-activation precision is untouched (unlike the FP8 path, which also
-quantizes activations for torch._scaled_mm).
+Conservative alternative to fp8_quantize: weights are *stored* as
+float8_e4m3fn with a per-output-channel scale, dequantized in-kernel, and all
+compute (accumulation and activations) stays bf16/fp32 — activation precision
+is untouched. The matmul is a hand-written Triton GEMV that streams the fp8
+weight matrix once and dequantizes in registers, so the memory-bandwidth win
+of 8-bit weights is kept without an fp8 matmul or activation scaling.
 
-Layer selection and forward-patching scaffolding (module walk,
-min_features gate, depformer-self_attn skip, bare in_proj handling,
-class-level gating/attention forward patches) is derived from
-fp8_quantize.py by amarrmb (github.com/amarrmb/personaplex), adapted to
-dispatch multiple quantization schemes per instance.
+Same integration contract as fp8_quantize:
 
-This commit uses a naive dequantize-then-cuBLAS linear as a correctness
-baseline; the fused Triton dequant-in-register GEMV and per-channel
-scaling land in the follow-up commit.
+    lm = loaders.get_moshi_lm(...)
+    quantize_model_w8a16(lm)   # replace weights + patch forwards
+    # ... warmup (CUDA graphs capture the Triton kernel) ...
+
+Layer coverage mirrors fp8_quantize exactly (same min_features gate, same
+depformer-self_attn skip, same bare in_proj handling) so the two schemes are
+directly comparable in latency and divergence measurements.
+
+The class-level forward patches dispatch on per-instance flags and also
+honor fp8_quantize's `_is_fp8` markers, so both schemes can coexist in one
+process (used by bench/divergence.py's three-way soak).
 """
 
 import logging
@@ -23,18 +30,91 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+
 logger = logging.getLogger(__name__)
 
 
-def w8a16_linear(x, w_fp8, scale, bias=None):
-    """Weight-only-8bit linear: dequantize to bf16, then cuBLAS.
+# ============================================================================
+# Triton GEMV: y[o] = (sum_i x[i] * W8[o,i]) * scale[o]   (bf16 x, fp8 W)
+#
+# Triton is imported lazily inside the builder so that `import moshi` and
+# this module work on CPU-only / Triton-less installs; the kernel is built
+# once and cached on first use.
+# ============================================================================
 
-    Naive correctness baseline — streams 1 byte/weight from memory only
-    after the dequant materialization, so it is NOT faster than bf16 yet;
-    the fused Triton GEMV replaces this in the next commit.
-    """
-    w = (w_fp8.to(torch.float32) * scale).to(x.dtype)
-    return F.linear(x, w, bias)
+_GEMV_KERNEL = None
+
+
+def _build_gemv_kernel():
+    global _GEMV_KERNEL
+    if _GEMV_KERNEL is not None:
+        return _GEMV_KERNEL
+    import importlib
+    g = globals()
+    g["triton"] = importlib.import_module("triton")
+    g["tl"] = importlib.import_module("triton.language")
+
+    @triton.jit
+    def _w8a16_gemv_kernel(
+        x_ptr, w_ptr, scale_ptr, bias_ptr, y_ptr,
+        IN: tl.constexpr, OUT,
+        HAS_BIAS: tl.constexpr,
+        BLOCK_OUT: tl.constexpr, BLOCK_IN: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        offs_o = pid * BLOCK_OUT + tl.arange(0, BLOCK_OUT)
+        mask_o = offs_o < OUT
+        acc = tl.zeros((BLOCK_OUT,), dtype=tl.float32)
+        for i in range(0, IN, BLOCK_IN):
+            offs_i = i + tl.arange(0, BLOCK_IN)
+            mask_i = offs_i < IN
+            x = tl.load(x_ptr + offs_i, mask=mask_i, other=0.0).to(tl.float32)
+            w = tl.load(w_ptr + offs_o[:, None] * IN + offs_i[None, :],
+                        mask=mask_o[:, None] & mask_i[None, :],
+                        other=0.0).to(tl.float32)
+            acc += tl.sum(w * x[None, :], axis=1)
+        scale = tl.load(scale_ptr + offs_o, mask=mask_o, other=0.0)
+        y = acc * scale
+        if HAS_BIAS:
+            y += tl.load(bias_ptr + offs_o, mask=mask_o,
+                         other=0.0).to(tl.float32)
+        tl.store(y_ptr + offs_o, y.to(y_ptr.dtype.element_ty), mask=mask_o)
+
+    _GEMV_KERNEL = _w8a16_gemv_kernel
+    return _GEMV_KERNEL
+
+
+def w8a16_linear(x, w_fp8, scale, bias=None):
+    """Weight-only-8bit linear. x: [..., IN] bf16; w_fp8: [OUT, IN] fp8e4m3;
+    scale: [OUT] fp32. Compute fp32-accumulate, output bf16."""
+    orig_shape = x.shape
+    in_features = w_fp8.shape[1]
+    out_features = w_fp8.shape[0]
+    x2 = x.reshape(-1, in_features)
+    if x2.shape[0] != 1:
+        # Rare non-decode path (prompt batches etc.): correctness fallback,
+        # full dequant + cuBLAS.
+        w = (w_fp8.to(torch.float32) * scale[:, None]).to(x.dtype)
+        return F.linear(x, w, bias).reshape(*orig_shape[:-1], out_features)
+    y = torch.empty(1, out_features, device=x.device, dtype=x.dtype)
+    # Tuned on GB10 (see M2 microbench): big shapes are bandwidth-bound and
+    # favor long inner blocks; small depformer shapes favor more warps.
+    if in_features >= 4096:
+        BLOCK_OUT, BLOCK_IN, num_warps = 16, 512, 2
+    else:
+        BLOCK_OUT, BLOCK_IN, num_warps = 16, 256, 4
+    kernel = _build_gemv_kernel()
+    grid = ((out_features + BLOCK_OUT - 1) // BLOCK_OUT,)
+    kernel[grid](
+        x2, w_fp8, scale,
+        bias if bias is not None else scale,  # dummy ptr when no bias
+        y,
+        IN=in_features, OUT=out_features,
+        HAS_BIAS=bias is not None,
+        BLOCK_OUT=BLOCK_OUT, BLOCK_IN=BLOCK_IN,
+        num_warps=num_warps,
+    )
+    return y.reshape(*orig_shape[:-1], out_features)
 
 
 # ============================================================================
@@ -142,11 +222,10 @@ def _make_attn_forward():
 # ============================================================================
 
 def _quantize_weight(w):
-    """Per-tensor fp8e4m3 storage (as in fp8_quantize). Returns
-    (w_fp8, scale_fp32 scalar)."""
-    amax = w.abs().amax()
-    scale = (amax / 448.0).clamp(min=1e-12).float().view(1)
-    w_fp8 = (w.float() / scale).to(torch.float8_e4m3fn)
+    """Per-output-channel fp8e4m3 storage. Returns (w_fp8, scale_fp32)."""
+    amax = w.abs().amax(dim=1).float()
+    scale = (amax / 448.0).clamp(min=1e-12)
+    w_fp8 = (w.float() / scale[:, None]).to(torch.float8_e4m3fn)
     return w_fp8, scale
 
 
@@ -164,6 +243,15 @@ def quantize_model_w8a16(model, min_features=512):
     Coverage mirrors fp8_quantize.quantize_model: skips small linears and
     depformer self_attn; also converts main-attention bare in_proj_weight.
     """
+    import importlib.util
+    if not torch.cuda.is_available():
+        raise RuntimeError("--w8a16 requires a CUDA device.")
+    if importlib.util.find_spec("triton") is None:
+        raise RuntimeError(
+            "--w8a16 requires Triton for its dequant GEMV kernel; install "
+            "it with `pip install triton`. No silent fallback is provided: "
+            "without the kernel the flag cannot meet its performance "
+            "contract.")
     import moshi.modules.gating as gating_mod
     import moshi.modules.transformer as tf_mod
 

--- a/moshi/pyproject.toml
+++ b/moshi/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "sentencepiece == 0.2",
     "sounddevice == 0.5",
     "sphn >= 0.1.4, < 0.2",
-    "torch >= 2.2.0, < 2.5",
+    "torch >= 2.2.0",
     "aiohttp>=3.10.5, <3.11",
 ]
 authors = [{name="Rajarshi Roy", email="rajarshir@nvidia.com"}]


### PR DESCRIPTION
**Depends on #102** (GB10 installability fixes — this branch is based on it; GitHub shows those commits here until #102 merges).


## Problem
PersonaPlex must produce one 80 ms audio frame every 80 ms. On NVIDIA
GB10 (DGX Spark / ThinkStation PGX / Jetson Thor class, sm_121, unified
LPDDR5X ~273 GB/s) stock bf16 measures ~101.7 ms/frame — real-time is
unreachable. Profiling (nsys, evidence links below) shows the LM step is
weight-streaming-bound: ~449 batch-1 GEMVs move ~13 GB of bf16 weights
per frame at only ~170-190 GB/s effective; dispatch overhead is <3 ms, so
the recoverable costs are weight bytes, redundant serve-path work, and
the depformer's unused half.

## What this PR adds (ordered commit story)
1. **amarrmb's FP8 groundwork** (cherry-picked with authorship
   preserved): `fp8_quantize.py` (torch._scaled_mm dynamic FP8), plus
   server-path optimizations (skip discarded second mimi stream, pinned
   DtoH, fp16+compiled mimi, frame profiling).
2. **Depformer early exit** (`--dep-q-exit 8`): dep_q=16 runs 16
   sequential depth steps but the serve flow always provides the
   user-side codebooks, so sampled outputs for codebooks 9..16 are
   always overwritten before use — skipping them is output-invariant
   (guards enforce the precondition). −10.3 ms (bf16) / −7.5 ms (w8a16).
3. **Mimi fast-path flags** (`--skip-other-mimi`, `--mimi-fp16`):
   amarrmb's server-side ideas as opt-in offline.py flags with None-safe
   plumbing (−5.4 ms and −1.9 ms).
4. **Quantization scaffolding + `--fp8` wiring** (derived work,
   Co-authored-by @amarrmb): offline-path wiring of their quantizer and
   the shared layer-selection/patching scaffolding in w8a16_quantize.py
   (module walk, min_features gate, depformer-self_attn skip, in_proj
   handling, class-patch machinery), with a naive dequant baseline.
5. **w8a16 kernel + presets** (original work): weights stored fp8-e4m3
   with per-output-channel scales, dequantized in-register by a
   hand-written Triton GEMV; **activations stay bf16**. The GEMV
   sustains 222-242 GB/s cold vs 126-226 for torch._scaled_mm on sm_121
   (which lands on an sm89 path), so weight-only beats full FP8 by
   ~16 ms/frame while perturbing logits ~25-30% less. `--fast` =
   `--w8a16 --dep-q-exit 8 --skip-other-mimi --mimi-fp16`.

**What is original here:** the Triton dequant-in-register GEMV, the
per-channel w8a16 scheme built on it, the `--fast` preset, and the
finding that weight-only 8-bit outperforms full FP8 on sm_121 (a
kernel-dispatch effect, not a numerics one) — plus the depformer
invariance proof and all measurements/quality gates. The FP8 quantizer,
the serve-path optimizations, and the quantization scaffolding are
amarrmb's work, carried with commit-level attribution.

## Ablation ladder (pre-registered protocol, 500 frames, real weights, GB10)
| config | total ms p50 / p99 / p99.9 | budget misses |
|---|---|---|
| bf16 stock | 101.66 / 103.52 / 103.59 | 475/475 |
| fp8 | 77.61 / 78.86 / 79.50 | 0 |
| w8a16 | 61.42 / 62.78 / 63.02 | 0 |
| w8a16 + depq8 | 53.82 / 54.91 / 55.34 | 0 |
| **--fast** | **46.47 / 47.58 / 48.11** | 0 |
| fast with fp32 mimi (variant) | 48.56 / 49.58 / 50.40 | 0 |

## Sustained validation (30 min, dmon alongside)
38,453 warm frames: p50 46.65 / p99 47.75 / **p99.9 48.20 / max 48.96 ms
— zero budget misses**. GPU 51->66 C, SM clocks −1.8%, 33->37 W: no
thermal cliff; the headline holds warm.

## Quality evidence (tolerance ladder)
- Teacher-forced drift (bf16 reference trajectory forced into each
  scheme, 3 seeds x 1500 frames; harness self-test = exactly 0.0):
  drift exponents ~0 for fp8 and w8a16 — **flat, no error
  accumulation; decisively sublinear = PASS.**
- Free-running stream health (5 seeds x 5000 frames): silence/click/
  spectral statistics inside the bf16 reference band; zero clicks >0.25
  in ~30k decoded frames.
- Perceptual layer: multi-seed listening matrix (5 schemes x 3 seeds,
  natural-female voice) in the fork's bench/results/20260724-audio-v2/.
- Full verdicts: bench/results/20260723-divergence/DIVERGENCE.md on the
  fork's pgx-plan branch.

## Reproduction / evidence links (fork, branch pgx-plan)
https://github.com/jethac/personaplex/tree/pgx-plan — bench/protocol.md
(pre-registered methodology), bench/bench.py + divergence.py (harness &
quality gates), bench/microbench/ (GEMV bandwidth lab + GB10 tuning
table), bench/results/ (per-frame CSVs, env blocks, ablations, soak,
audio). The harness + GB10 playbook are available as a follow-up PR on
request.

**Zero-build install for GB10 users** (no Rust, no source builds):
https://github.com/jethac/personaplex-gb10 — public repro repo with the
harness, pre-registered protocol, GB10 playbook, and prebuilt wheels
(release v0.1.0: this branch as a py3 wheel + an aarch64 cp312 sphn
wheel), installed by one script and verified end-to-end from the release
on a clean venv.

## Pinned environment
Lenovo ThinkStation PGX — GB10 (sm_121, 48 SMs, 25 MB L2), aarch64,
128 GB unified LPDDR5X; Ubuntu 24.04, driver 595.71.05, CUDA 13.0;
python 3.12.3, torch 2.13.0+cu130, triton 3.7.1 with system ptxas
symlinked over the bundled ptxas-blackwell.

## Behavioral guarantees

**Zero change without flags.** Every optimization is opt-in; each verbatim
contributor cherry-pick is immediately followed by a gating fixup commit so
that at the branch tip, stock invocation matches upstream. Evidence: a
seeded no-flag offline run (seed 42424, 30 s input, 375 frames, real
weights) on the branch tip vs upstream/main produced **byte-identical
output WAV and byte-identical token stream** (`cmp` on both artifacts).
The only remaining non-numeric deltas are (a) a per-50-frames timing log
line in the server loop (observability only; happy to gate or drop it on
request) and (b) one informational log line at startup on GB10-class
devices (sm_121) when no perf flag is active, pointing users at the
opt-in flags — added as the FINAL commit of the series so a maintainer
can drop it independently; it fires on no other arch and never when any
perf flag is set.

**Per-flag prerequisites** (checked at startup/model-build time with
actionable RuntimeErrors; no silent fallbacks — if a flag cannot meet its
performance contract, it errors rather than quietly degrading):

| flag | requirement | check |
|---|---|---|
| `--fp8` | CUDA, compute capability >= 8.9, `torch._scaled_mm` | explicit startup check in server and offline wiring |
| `--w8a16` | CUDA + Triton | module imports without Triton (lazy kernel builder, built+cached on first use); quantize errors with install hint if Triton missing |
| `--mimi-fp16` | working torch.compile backend (Triton on CUDA) | checked at argument parse time. Perceptual note: a single-trial report of onset softening was falsified by a 5-pair blind matched-pairs A/B (0/5 discrimination; onset character tracks the sampling seed, not mimi precision) — part of --fast |
| `--dep-q-exit` | none (pure logic) | precondition guard: rejects steps without user input tokens |
| `--skip-other-mimi` | none (pure logic) | n/a |
| `--pinned-io` | CUDA | n/a (allocation-time) |
| `--fast` | composes the above | composed startup check that names the specific missing prerequisite |

No architecture-sniffing anywhere: capability checks only, no `sm_121`
conditionals; the Triton ptxas symlink workaround is documentation-only
(GB10 playbook), never code. The Triton GEMV is generic sm_80+.

## Attribution
| what | who | provenance |
|---|---|---|
| fp8_quantize.py, server-path opts (skip-other, pinned DtoH, fp16 mimi) | @amarrmb | cherry-pick -x of amarrmb/personaplex 94cbbbd (also validated by them: 74 ms on DGX Spark) |
| encode_from_sphn dtype cast (in PR `pr-build-fixes`) | @amarrmb | cherry-pick -x of add7726 |
| depformer early-exit observation | @gplv2 | NVIDIA/personaplex#3 discussion |
| early-exit implementation + invariance proof + guards | jethac | this PR |
| mimi flags adaptation (offline path) | jethac, Co-authored-by @amarrmb | this PR |
| quantization scaffolding (layer walk/gates/class patches) + --fp8 wiring | derived from @amarrmb's fp8_quantize.py | this PR, commit "quantization scaffolding", Co-authored-by trailer |
| w8a16 scheme, Triton dequant GEMV, per-channel scaling, --w8a16/--fast, all measurements & quality gates | jethac | this PR, commit "w8a16: weight-only..." (no co-author: original work) |
| torch-pin conflict report / ptxas notes | @acatovic / @listerheaton | NVIDIA/personaplex#3 |

@amarrmb: please flag any attribution adjustment you'd like — happy to
amend.

## Gating notes
- All flags are opt-in and defaults are unchanged. The perceptual layer is
  complete: a multi-seed listening matrix plus a 5-pair blind matched-pairs
  A/B on mimi precision (0/5 discrimination; onset character tracks the
  sampling seed, not precision) — full write-up in the fork's
  bench/results/20260724-audio-v3/ and DIVERGENCE.md.
- Known unknowns: sm_121, n=1 machine (plus amarrmb's Spark/Thor for
  the fp8/server parts); task-level metrics (WER etc.) not measured.

## Upstream overlap (pre-flight scan, 2026-07-24)
- **PR #72** (@mvanhorn, Apr 6): removes the unused other_mimi instance
  outright (~200 MB memory saving) — the same discarded-work observation
  behind our --skip-other-mimi (credit to them for reaching it
  independently). Difference: #72 changes default behavior by deleting
  the second stream; ours keeps stock behavior byte-identical and makes
  the skip opt-in per this PR's behavioral guarantees. If maintainers
  prefer #72's hard removal, our flag reduces to a no-op and we would
  rebase; if they prefer conservative defaults, #72's saving is
  available here behind the flag.
- server.py / offline.py are contended files across many open PRs
  (#101 path-traversal fix, #84 H20 compile fast-path, #79 multi-GPU,
  #75/#70 security, #62 HF_HUB_OFFLINE, #44 sphn API, #20 logging
  refactor, macOS/MPS series #100/#91/#64/#25/#35). No semantic
  conflicts with this series identified beyond #72; we will rebase at
  filing time against whatever has merged.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
